### PR TITLE
Bump to v0.3.3 — republish with built bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
-## [0.3.2] — Unreleased
+## [0.3.3] — Unreleased
+
+### 🐛 Bug fixes
+
+- **Republish with built bundles** — v0.3.2 was published without running the build step, so the bundled runtime scripts in `.clancy/` still contained the old JQL bug. This release is identical to 0.3.2 but with correctly built bundles.
+
+---
+
+## [0.3.2] — 2026-03-12
 
 ### 🐛 Bug fixes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chief-clancy",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chief-clancy",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "bin": {
         "clancy": "dist/installer/install.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chief-clancy",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Autonomous, board-driven development for Claude Code — scaffolds docs, integrates Kanban boards, runs tickets in a loop.",
   "keywords": [
     "claude",


### PR DESCRIPTION
## Summary

- v0.3.2 was published without running the build step, so the bundled runtime scripts in `.clancy/` still contained the old JQL `AND ORDER BY` bug
- This bumps to 0.3.3 so npm accepts the republish with correctly built bundles
- No code changes — just version bump and changelog

## Test plan

- [ ] `npm run build` produces bundles with the fix (`grep "ORDER BY" dist/bundle/clancy-once.js`)
- [ ] `npm publish` succeeds
- [ ] `npx -y chief-clancy@0.3.3` installs fixed `.clancy/clancy-once.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)