### PR TITLE
fix: make Jira search response total/isLast optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [0.3.5] — 2026-03-12
+
+### 🐛 Bug fixes
+
+- **Fixed Jira search schema validation** — The `POST /rest/api/3/search/jql` endpoint returns `isLast` instead of `total` in its response. The Zod schema required `total` as a mandatory number, causing validation to fail at runtime. Both fields are now optional.
+
+---
+
 ## [0.3.4] — 2026-03-12
 
 ### ✨ Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chief-clancy",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chief-clancy",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "bin": {
         "clancy": "dist/installer/install.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chief-clancy",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Autonomous, board-driven development for Claude Code — scaffolds docs, integrates Kanban boards, runs tickets in a loop.",
   "keywords": [
     "claude",

--- a/src/schemas/jira.ts
+++ b/src/schemas/jira.ts
@@ -26,7 +26,8 @@ const jiraIssueSchema = z.object({
 
 /** Response from `POST /rest/api/3/search/jql`. */
 export const jiraSearchResponseSchema = z.object({
-  total: z.number(),
+  total: z.optional(z.number()),
+  isLast: z.optional(z.boolean()),
   issues: z.array(jiraIssueSchema),
 });
 


### PR DESCRIPTION
## Summary

- The `POST /rest/api/3/search/jql` endpoint returns `isLast: true` instead of a numeric `total` field
- The Zod schema required `total` as mandatory, causing runtime validation to fail when running `/clancy:once`
- Both `total` and `isLast` are now optional — neither is used in script logic, only for schema validation
- Bumped version to 0.3.5

## Test plan

- [x] `/clancy:once` successfully fetches and picks up a Jira ticket
- [x] `/clancy:status` and `/clancy:review` still work as before
- [x] 142 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)