### PR TITLE
release: v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [0.3.5] — 2026-03-12
+
+### 🐛 Bug fixes
+
+- **Fixed Jira search schema validation** — The `POST /rest/api/3/search/jql` endpoint returns `isLast` instead of `total` in its response. The Zod schema required `total` as a mandatory number, causing validation to fail at runtime. Both fields are now optional.
+
+---
+
 ## [0.3.4] — 2026-03-12
 
 ### ✨ Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chief-clancy",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chief-clancy",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "bin": {
         "clancy": "dist/installer/install.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chief-clancy",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Autonomous, board-driven development for Claude Code — scaffolds docs, integrates Kanban boards, runs tickets in a loop.",
   "keywords": [
     "claude",

--- a/src/schemas/jira.ts
+++ b/src/schemas/jira.ts
@@ -26,7 +26,8 @@ const jiraIssueSchema = z.object({
 
 /** Response from `POST /rest/api/3/search/jql`. */
 export const jiraSearchResponseSchema = z.object({
-  total: z.number(),
+  total: z.optional(z.number()),
+  isLast: z.optional(z.boolean()),
   issues: z.array(jiraIssueSchema),
 });
 


### PR DESCRIPTION
## Summary

- Fixed Jira search schema validation — `POST /rest/api/3/search/jql` returns `isLast` instead of `total`. Both fields are now optional.

## Post-merge steps

- [x] Tag: `git tag v0.3.5 && git push origin v0.3.5`
- [x] Verify GitHub Actions release workflow
- [x] `npm run build && npm publish`
- [x] Merge `main` back into `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)