### PR TITLE
release: v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [0.3.6] — 2026-03-12
+
+### ✨ Features
+
+- **Feasibility check before branch creation** — The once orchestrator now runs a lightweight Claude evaluation before creating branches or transitioning tickets. If a ticket requires external tools, manual testing, or non-code work, it is skipped cleanly with no dangling branches or stuck tickets. Fails open — if Claude is unavailable, the ticket proceeds normally.
+
+---
+
 ## [0.3.5] — 2026-03-12
 
 ### 🐛 Bug fixes

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 [![npm](https://img.shields.io/npm/v/chief-clancy?style=for-the-badge&color=cb3837)](https://www.npmjs.com/package/chief-clancy) [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=for-the-badge)](./LICENSE) [![Tests](https://img.shields.io/badge/tests-146%20passing-brightgreen?style=for-the-badge)](docs/TESTING.md) [![GitHub Stars](https://img.shields.io/github/stars/Pushedskydiver/clancy?style=for-the-badge)](https://github.com/Pushedskydiver/clancy/stargazers)
 
+> [!WARNING]
+> Clancy is in early development. Expect bugs, breaking changes, and rough edges. If you hit an issue, please [open a bug report](https://github.com/Pushedskydiver/clancy/issues/new).
+
 ```bash
 npx chief-clancy
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chief-clancy",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chief-clancy",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "MIT",
       "bin": {
         "clancy": "dist/installer/install.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chief-clancy",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Autonomous, board-driven development for Claude Code — scaffolds docs, integrates Kanban boards, runs tickets in a loop.",
   "keywords": [
     "claude",

--- a/src/scripts/once/once.test.ts
+++ b/src/scripts/once/once.test.ts
@@ -5,6 +5,7 @@ import { closeIssue } from '~/scripts/board/github/github.js';
 import { fetchTicket as fetchJiraTicket } from '~/scripts/board/jira/jira.js';
 import { invokeClaudeSession } from '~/scripts/shared/claude-cli/claude-cli.js';
 import { detectBoard } from '~/scripts/shared/env-schema/env-schema.js';
+import { checkFeasibility } from '~/scripts/shared/feasibility/feasibility.js';
 import {
   checkout,
   deleteBranch,
@@ -66,6 +67,10 @@ vi.mock('~/scripts/shared/claude-cli/claude-cli.js', () => ({
   invokeClaudeSession: vi.fn(() => true),
 }));
 
+vi.mock('~/scripts/shared/feasibility/feasibility.js', () => ({
+  checkFeasibility: vi.fn(() => ({ feasible: true })),
+}));
+
 vi.mock('~/scripts/shared/notify/notify.js', () => ({
   sendNotification: vi.fn(() => Promise.resolve()),
 }));
@@ -90,6 +95,7 @@ const mockDeleteBranch = vi.mocked(deleteBranch);
 const mockAppendProgress = vi.mocked(appendProgress);
 const mockSendNotification = vi.mocked(sendNotification);
 const mockCloseIssue = vi.mocked(closeIssue);
+const mockCheckFeasibility = vi.mocked(checkFeasibility);
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -306,6 +312,42 @@ describe('run', () => {
     log.mockRestore();
 
     expect(mockEnsureBranch).toHaveBeenCalledWith('main', 'main');
+  });
+
+  it('skips ticket when feasibility check fails', async () => {
+    setupJiraHappyPath();
+    mockCheckFeasibility.mockReturnValue({
+      feasible: false,
+      reason: 'requires OneTrust admin access',
+    });
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await run([]);
+    log.mockRestore();
+
+    // No branch created, no Claude session
+    expect(mockEnsureBranch).not.toHaveBeenCalled();
+    expect(mockInvokeClaude).not.toHaveBeenCalled();
+
+    // Progress logged as SKIPPED
+    expect(mockAppendProgress).toHaveBeenCalledWith(
+      expect.any(String),
+      'PROJ-123',
+      'Add login page',
+      'SKIPPED',
+    );
+  });
+
+  it('proceeds when feasibility check passes', async () => {
+    setupJiraHappyPath();
+    mockCheckFeasibility.mockReturnValue({ feasible: true });
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await run([]);
+    log.mockRestore();
+
+    expect(mockEnsureBranch).toHaveBeenCalled();
+    expect(mockInvokeClaude).toHaveBeenCalled();
   });
 
   it('handles unexpected errors gracefully', async () => {

--- a/src/scripts/once/once.ts
+++ b/src/scripts/once/once.ts
@@ -2,8 +2,8 @@
  * Unified once orchestrator — replaces all three `clancy-once-*.sh` scripts.
  *
  * Full lifecycle: preflight → detect board → fetch ticket → compute branches →
- * [dry-run gate] → transition In Progress → create branch → invoke Claude →
- * squash merge → transition Done → log → notify.
+ * [dry-run gate] → feasibility check → create branch → transition In Progress →
+ * invoke Claude → squash merge → transition Done → log → notify.
  *
  * All errors exit with code 0 (not 1). This is intentional — the AFK runner
  * detects stop conditions by parsing stdout, not exit codes.
@@ -37,6 +37,7 @@ import {
 import { invokeClaudeSession } from '~/scripts/shared/claude-cli/claude-cli.js';
 import { detectBoard } from '~/scripts/shared/env-schema/env-schema.js';
 import type { BoardConfig } from '~/scripts/shared/env-schema/env-schema.js';
+import { checkFeasibility } from '~/scripts/shared/feasibility/feasibility.js';
 import {
   checkout,
   currentBranch,
@@ -365,19 +366,40 @@ export async function run(argv: string[]): Promise<void> {
     }
     console.log('');
 
-    // 9. Git: set up branches
+    // 9. Feasibility check
+    console.log(dim('  Checking feasibility...'));
+    const feasibility = checkFeasibility(
+      {
+        key: ticket.key,
+        title: ticket.title,
+        description: ticket.description,
+      },
+      config.env.CLANCY_MODEL,
+    );
+
+    if (!feasibility.feasible) {
+      const reason = feasibility.reason ?? 'not implementable as code changes';
+      console.log(yellow(`⏭️ Ticket skipped [${ticket.key}]: ${reason}`));
+      appendProgress(process.cwd(), ticket.key, ticket.title, 'SKIPPED');
+      return;
+    }
+
+    console.log(green('  ✓ Feasibility check passed'));
+    console.log('');
+
+    // 10. Git: set up branches
     originalBranch = currentBranch();
     ensureBranch(targetBranch, baseBranch);
     checkout(targetBranch);
     checkout(ticketBranch, true);
 
-    // 10. Transition to In Progress (best-effort)
+    // 11. Transition to In Progress (best-effort)
     const statusInProgress = config.env.CLANCY_STATUS_IN_PROGRESS;
     if (statusInProgress) {
       await transitionToStatus(config, ticket, statusInProgress);
     }
 
-    // 11. Build prompt and invoke Claude
+    // 12. Build prompt and invoke Claude
     const prompt = buildPrompt({
       provider: config.provider,
       key: ticket.key,
@@ -396,7 +418,7 @@ export async function run(argv: string[]): Promise<void> {
       return;
     }
 
-    // 12. Squash merge
+    // 13. Squash merge
     checkout(targetBranch);
     const commitMsg = `feat(${ticket.key}): ${ticket.title}`;
     const hadChanges = squashMerge(ticketBranch, commitMsg);
@@ -409,10 +431,10 @@ export async function run(argv: string[]): Promise<void> {
       );
     }
 
-    // 13. Delete feature branch
+    // 14. Delete feature branch
     deleteBranch(ticketBranch);
 
-    // 14. Transition to Done / close issue (best-effort)
+    // 15. Transition to Done / close issue (best-effort)
     const statusDone = config.env.CLANCY_STATUS_DONE;
 
     if (config.provider === 'github') {
@@ -438,7 +460,7 @@ export async function run(argv: string[]): Promise<void> {
       await transitionToStatus(config, ticket, statusDone);
     }
 
-    // 15. Log progress
+    // 16. Log progress
     appendProgress(process.cwd(), ticket.key, ticket.title, 'DONE');
 
     const elapsed = formatDuration(Date.now() - startTime);
@@ -446,7 +468,7 @@ export async function run(argv: string[]): Promise<void> {
     console.log(green(`🏁 ${ticket.key} complete`) + dim(` (${elapsed})`));
     console.log(dim('  "Bake \'em away, toys."'));
 
-    // 16. Send notification (best-effort)
+    // 17. Send notification (best-effort)
     const webhook = config.env.CLANCY_NOTIFY_WEBHOOK;
 
     if (webhook) {

--- a/src/scripts/shared/claude-cli/claude-cli.test.ts
+++ b/src/scripts/shared/claude-cli/claude-cli.test.ts
@@ -1,10 +1,10 @@
 import * as childProcess from 'node:child_process';
 import { describe, expect, it, vi } from 'vitest';
 
-import { invokeClaudeSession } from './claude-cli.js';
+import { invokeClaudePrint, invokeClaudeSession } from './claude-cli.js';
 
 vi.mock('node:child_process', () => ({
-  spawnSync: vi.fn(() => ({ status: 0 })),
+  spawnSync: vi.fn(() => ({ status: 0, stdout: '', stderr: '' })),
 }));
 
 describe('invokeClaudeSession', () => {
@@ -54,5 +54,53 @@ describe('invokeClaudeSession', () => {
     });
 
     expect(invokeClaudeSession('test prompt')).toBe(false);
+  });
+});
+
+describe('invokeClaudePrint', () => {
+  it('spawns claude with -p flag and captures stdout', () => {
+    vi.mocked(childProcess.spawnSync).mockReturnValueOnce({
+      status: 0,
+      signal: null,
+      output: [],
+      pid: 0,
+      stdout: 'FEASIBLE',
+      stderr: '',
+    });
+
+    const result = invokeClaudePrint('test prompt');
+
+    expect(childProcess.spawnSync).toHaveBeenCalledWith(
+      'claude',
+      ['-p', '--dangerously-skip-permissions'],
+      expect.objectContaining({
+        input: 'test prompt',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }),
+    );
+    expect(result).toEqual({ stdout: 'FEASIBLE', ok: true });
+  });
+
+  it('includes --model flag when model is specified', () => {
+    invokeClaudePrint('test prompt', 'sonnet');
+
+    expect(childProcess.spawnSync).toHaveBeenCalledWith(
+      'claude',
+      ['-p', '--dangerously-skip-permissions', '--model', 'sonnet'],
+      expect.objectContaining({ input: 'test prompt' }),
+    );
+  });
+
+  it('returns ok=false on non-zero exit', () => {
+    vi.mocked(childProcess.spawnSync).mockReturnValueOnce({
+      status: 1,
+      signal: null,
+      output: [],
+      pid: 0,
+      stdout: '',
+      stderr: '',
+    });
+
+    expect(invokeClaudePrint('test prompt').ok).toBe(false);
   });
 });

--- a/src/scripts/shared/claude-cli/claude-cli.ts
+++ b/src/scripts/shared/claude-cli/claude-cli.ts
@@ -7,6 +7,38 @@
 import { spawnSync } from 'node:child_process';
 
 /**
+ * Invoke Claude in print mode and capture the response.
+ *
+ * Uses `claude -p` for a single-prompt, non-interactive invocation.
+ * Stdout is captured (not streamed) so the caller can parse it.
+ *
+ * @param prompt - The prompt to send.
+ * @param model - Optional model override.
+ * @returns The captured stdout and whether the process succeeded.
+ */
+export function invokeClaudePrint(
+  prompt: string,
+  model?: string,
+): { stdout: string; ok: boolean } {
+  const args = ['-p', '--dangerously-skip-permissions'];
+
+  if (model) {
+    args.push('--model', model);
+  }
+
+  const result = spawnSync('claude', args, {
+    input: prompt,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    encoding: 'utf8',
+  });
+
+  return {
+    stdout: result.stdout ?? '',
+    ok: result.status === 0 && !result.error,
+  };
+}
+
+/**
  * Invoke a Claude Code session with the given prompt.
  *
  * Pipes the prompt to stdin and streams stdout/stderr live.

--- a/src/scripts/shared/feasibility/feasibility.test.ts
+++ b/src/scripts/shared/feasibility/feasibility.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildFeasibilityPrompt,
+  checkFeasibility,
+  parseFeasibilityResponse,
+} from './feasibility.js';
+
+vi.mock('~/scripts/shared/claude-cli/claude-cli.js', () => ({
+  invokeClaudePrint: vi.fn(() => ({ stdout: 'FEASIBLE', ok: true })),
+}));
+
+describe('buildFeasibilityPrompt', () => {
+  it('includes ticket key, title, and description', () => {
+    const prompt = buildFeasibilityPrompt({
+      key: 'PROJ-1',
+      title: 'Add login button',
+      description: 'Add a login button to the header.',
+    });
+
+    expect(prompt).toContain('[PROJ-1] Add login button');
+    expect(prompt).toContain('Add a login button to the header.');
+  });
+});
+
+describe('parseFeasibilityResponse', () => {
+  it('returns feasible for FEASIBLE response', () => {
+    expect(parseFeasibilityResponse('FEASIBLE')).toEqual({ feasible: true });
+  });
+
+  it('returns feasible for FEASIBLE with extra whitespace', () => {
+    expect(parseFeasibilityResponse('  FEASIBLE  \n')).toEqual({
+      feasible: true,
+    });
+  });
+
+  it('returns infeasible with reason', () => {
+    const result = parseFeasibilityResponse(
+      'INFEASIBLE: requires OneTrust admin access',
+    );
+    expect(result).toEqual({
+      feasible: false,
+      reason: 'requires OneTrust admin access',
+    });
+  });
+
+  it('returns infeasible without reason when none given', () => {
+    expect(parseFeasibilityResponse('INFEASIBLE')).toEqual({
+      feasible: false,
+      reason: undefined,
+    });
+  });
+
+  it('is case-insensitive', () => {
+    expect(parseFeasibilityResponse('infeasible: reason')).toEqual({
+      feasible: false,
+      reason: 'reason',
+    });
+  });
+
+  it('fails open on empty output', () => {
+    expect(parseFeasibilityResponse('')).toEqual({ feasible: true });
+  });
+
+  it('fails open on malformed output', () => {
+    expect(parseFeasibilityResponse('I think this is feasible')).toEqual({
+      feasible: true,
+    });
+  });
+
+  it('uses last line of multi-line output', () => {
+    const output = 'Some preamble\nINFEASIBLE: needs manual testing';
+    expect(parseFeasibilityResponse(output)).toEqual({
+      feasible: false,
+      reason: 'needs manual testing',
+    });
+  });
+});
+
+describe('checkFeasibility', () => {
+  it('returns feasible when Claude says FEASIBLE', async () => {
+    const { invokeClaudePrint } =
+      await import('~/scripts/shared/claude-cli/claude-cli.js');
+    vi.mocked(invokeClaudePrint).mockReturnValue({
+      stdout: 'FEASIBLE',
+      ok: true,
+    });
+
+    const result = checkFeasibility({
+      key: 'PROJ-1',
+      title: 'Test',
+      description: 'desc',
+    });
+    expect(result).toEqual({ feasible: true });
+  });
+
+  it('returns infeasible when Claude says INFEASIBLE', async () => {
+    const { invokeClaudePrint } =
+      await import('~/scripts/shared/claude-cli/claude-cli.js');
+    vi.mocked(invokeClaudePrint).mockReturnValue({
+      stdout: 'INFEASIBLE: requires external API',
+      ok: true,
+    });
+
+    const result = checkFeasibility({
+      key: 'PROJ-1',
+      title: 'Test',
+      description: 'desc',
+    });
+    expect(result).toEqual({
+      feasible: false,
+      reason: 'requires external API',
+    });
+  });
+
+  it('fails open when Claude process fails', async () => {
+    const { invokeClaudePrint } =
+      await import('~/scripts/shared/claude-cli/claude-cli.js');
+    vi.mocked(invokeClaudePrint).mockReturnValue({ stdout: '', ok: false });
+
+    const result = checkFeasibility({
+      key: 'PROJ-1',
+      title: 'Test',
+      description: 'desc',
+    });
+    expect(result).toEqual({ feasible: true });
+  });
+
+  it('passes model to invokeClaudePrint', async () => {
+    const { invokeClaudePrint } =
+      await import('~/scripts/shared/claude-cli/claude-cli.js');
+    vi.mocked(invokeClaudePrint).mockReturnValue({
+      stdout: 'FEASIBLE',
+      ok: true,
+    });
+
+    checkFeasibility(
+      { key: 'PROJ-1', title: 'Test', description: 'desc' },
+      'sonnet',
+    );
+
+    expect(invokeClaudePrint).toHaveBeenCalledWith(
+      expect.any(String),
+      'sonnet',
+    );
+  });
+});

--- a/src/scripts/shared/feasibility/feasibility.ts
+++ b/src/scripts/shared/feasibility/feasibility.ts
@@ -1,0 +1,85 @@
+/**
+ * Lightweight feasibility check — evaluates whether a ticket can be
+ * implemented as pure code changes before creating branches or
+ * transitioning board status.
+ *
+ * Uses `claude -p` (print mode) for a fast, single-prompt evaluation.
+ * Fails open: if Claude is unavailable or output is malformed the
+ * ticket is assumed feasible so work is never silently blocked.
+ */
+import { invokeClaudePrint } from '~/scripts/shared/claude-cli/claude-cli.js';
+
+export type FeasibilityResult = {
+  feasible: boolean;
+  reason?: string;
+};
+
+/**
+ * Build the feasibility evaluation prompt.
+ */
+export function buildFeasibilityPrompt(ticket: {
+  key: string;
+  title: string;
+  description: string;
+}): string {
+  return [
+    'You are evaluating whether a ticket can be implemented as pure code changes in a repository.',
+    '',
+    `Ticket: [${ticket.key}] ${ticket.title}`,
+    'Description:',
+    ticket.description,
+    '',
+    'Can this ticket be completed entirely through code changes committed to a git repository?',
+    '',
+    'Answer INFEASIBLE if the ticket requires ANY of:',
+    '- Manual testing or configuration in external tools or admin panels',
+    '- Access to external services, APIs, or platforms not available in the codebase',
+    '- Physical, hardware, or infrastructure changes',
+    '- Design assets that do not yet exist',
+    '- Deployment or infrastructure changes outside the repository',
+    '- Human judgment calls that require stakeholder input',
+    '',
+    'Answer with exactly one line in this format:',
+    'FEASIBLE',
+    'or',
+    'INFEASIBLE: one-line reason',
+    '',
+    'Do not include any other text.',
+  ].join('\n');
+}
+
+/**
+ * Parse the raw Claude output into a feasibility result.
+ *
+ * Fails open — malformed or empty output is treated as feasible.
+ */
+export function parseFeasibilityResponse(stdout: string): FeasibilityResult {
+  const line = stdout.trim().split('\n').pop()?.trim() ?? '';
+
+  if (/^INFEASIBLE/i.test(line)) {
+    const reason = line.replace(/^INFEASIBLE:?\s*/i, '').trim() || undefined;
+    return { feasible: false, reason };
+  }
+
+  // Fail open — FEASIBLE, empty, or malformed output all pass
+  return { feasible: true };
+}
+
+/**
+ * Run a feasibility check for a ticket.
+ *
+ * @returns A result indicating whether the ticket is feasible and an
+ *   optional reason if not.
+ */
+export function checkFeasibility(
+  ticket: { key: string; title: string; description: string },
+  model?: string,
+): FeasibilityResult {
+  const prompt = buildFeasibilityPrompt(ticket);
+  const { stdout, ok } = invokeClaudePrint(prompt, model);
+
+  // Fail open — if Claude failed to run, assume feasible
+  if (!ok) return { feasible: true };
+
+  return parseFeasibilityResponse(stdout);
+}

--- a/src/workflows/once.md
+++ b/src/workflows/once.md
@@ -83,11 +83,18 @@ Stream output directly — do not buffer or summarise.
 
 ## Step 3 — Result
 
-On success, echo the result line from the script output:
+On success (output contains `complete`), echo:
 ```
 ✅ {TICKET-KEY} complete.
 
 "That's some fine police work there, Lou."
+```
+
+On skip (output contains `Ticket skipped`), echo:
+```
+⏭️ {TICKET-KEY} skipped — {reason from output}.
+
+"Not on my watch." — The ticket requires work that Clancy can't do as code changes. A human should handle this one.
 ```
 
 On failure:


### PR DESCRIPTION
## Summary

- **Feasibility check** — The once orchestrator now runs a lightweight Claude evaluation before creating branches or transitioning tickets. Infeasible tickets (requiring external tools, manual testing, etc.) are skipped cleanly with no dangling branches or stuck tickets. Fails open.
- **Skip messaging** — Skipped tickets show `⏭️ Ticket skipped` instead of `✅ complete`. The once workflow now has three outcome states: complete, skipped, failure.
- **Early development warning** — Added a warning banner to the README.
- **Jira schema fix** (from v0.3.5) — `total`/`isLast` both optional in search response.
- **Non-interactive installer** (from v0.3.4) — `--global`/`--local` CLI flags.

## Post-merge steps

- [x] Tag: `git tag v0.3.6 && git push origin v0.3.6`
- [x] Verify GitHub Actions release workflow
- [x] `npm run build && npm publish`
- [x] Merge `main` back into `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)