### PR TITLE
Fix feasibility check nesting error inside Claude Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [0.3.7] — 2026-03-12
+
+### 🐛 Bug fixes
+
+- **Fixed feasibility check nesting error** — The `claude -p` call in the feasibility check created a blocked nested session when running inside Claude Code via `/clancy:once`. The workflow now evaluates feasibility directly (no subprocess) using the dry-run output, then runs the script with `--skip-feasibility`. The script-level `claude -p` check is preserved for standalone/AFK mode where it works correctly.
+
+---
+
 ## [0.3.6] — 2026-03-12
 
 ### ✨ Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chief-clancy",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chief-clancy",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "MIT",
       "bin": {
         "clancy": "dist/installer/install.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chief-clancy",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Autonomous, board-driven development for Claude Code — scaffolds docs, integrates Kanban boards, runs tickets in a loop.",
   "keywords": [
     "claude",

--- a/src/scripts/once/once.test.ts
+++ b/src/scripts/once/once.test.ts
@@ -350,6 +350,18 @@ describe('run', () => {
     expect(mockInvokeClaude).toHaveBeenCalled();
   });
 
+  it('skips feasibility check when --skip-feasibility is passed', async () => {
+    setupJiraHappyPath();
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await run(['--skip-feasibility']);
+    log.mockRestore();
+
+    expect(mockCheckFeasibility).not.toHaveBeenCalled();
+    expect(mockEnsureBranch).toHaveBeenCalled();
+    expect(mockInvokeClaude).toHaveBeenCalled();
+  });
+
   it('handles unexpected errors gracefully', async () => {
     mockPreflight.mockImplementation(() => {
       throw new Error('boom');

--- a/src/scripts/once/once.ts
+++ b/src/scripts/once/once.ts
@@ -258,6 +258,7 @@ async function transitionToStatus(
  */
 export async function run(argv: string[]): Promise<void> {
   const dryRun = argv.includes('--dry-run');
+  const skipFeasibility = argv.includes('--skip-feasibility');
 
   const startTime = Date.now();
 
@@ -347,6 +348,9 @@ export async function run(argv: string[]): Promise<void> {
         console.log(`  Blockers:       ${ticket.blockers}`);
       }
       console.log(`  Target branch:  ${ticketBranch} → ${targetBranch}`);
+      if (ticket.description) {
+        console.log(`  Description:    ${ticket.description}`);
+      }
       console.log(yellow('─────────────────────────────────────────────────'));
       console.log(dim('  No changes made. Remove --dry-run to run for real.'));
       return;
@@ -366,25 +370,29 @@ export async function run(argv: string[]): Promise<void> {
     }
     console.log('');
 
-    // 9. Feasibility check
-    console.log(dim('  Checking feasibility...'));
-    const feasibility = checkFeasibility(
-      {
-        key: ticket.key,
-        title: ticket.title,
-        description: ticket.description,
-      },
-      config.env.CLANCY_MODEL,
-    );
+    // 9. Feasibility check (skipped when --skip-feasibility is passed;
+    //    the workflow handles feasibility evaluation directly in that case)
+    if (!skipFeasibility) {
+      console.log(dim('  Checking feasibility...'));
+      const feasibility = checkFeasibility(
+        {
+          key: ticket.key,
+          title: ticket.title,
+          description: ticket.description,
+        },
+        config.env.CLANCY_MODEL,
+      );
 
-    if (!feasibility.feasible) {
-      const reason = feasibility.reason ?? 'not implementable as code changes';
-      console.log(yellow(`⏭️ Ticket skipped [${ticket.key}]: ${reason}`));
-      appendProgress(process.cwd(), ticket.key, ticket.title, 'SKIPPED');
-      return;
+      if (!feasibility.feasible) {
+        const reason =
+          feasibility.reason ?? 'not implementable as code changes';
+        console.log(yellow(`⏭️ Ticket skipped [${ticket.key}]: ${reason}`));
+        appendProgress(process.cwd(), ticket.key, ticket.title, 'SKIPPED');
+        return;
+      }
+
+      console.log(green('  ✓ Feasibility check passed'));
     }
-
-    console.log(green('  ✓ Feasibility check passed'));
     console.log('');
 
     // 10. Git: set up branches

--- a/src/workflows/once.md
+++ b/src/workflows/once.md
@@ -47,21 +47,6 @@ Pick up exactly one ticket from the Kanban board, implement it, commit, squash-m
 
 Check if the user passed `--dry-run` as an argument to the slash command.
 
-**Without `--dry-run`:**
-
-Display:
-```
-🚨 Clancy — Once
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-"I'm on the case." — Running for one ticket.
-```
-
-Execute:
-```bash
-node .clancy/clancy-once.js
-```
-
 **With `--dry-run`:**
 
 Display:
@@ -75,6 +60,54 @@ Display:
 Execute:
 ```bash
 node .clancy/clancy-once.js --dry-run
+```
+
+Stream output directly — do not buffer or summarise. Stop here (do not continue to Step 3).
+
+**Without `--dry-run`:**
+
+Display:
+```
+🚨 Clancy — Once
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+"I'm on the case." — Running for one ticket.
+```
+
+### 2a. Fetch ticket details
+
+Execute a dry-run first to retrieve ticket details:
+```bash
+node .clancy/clancy-once.js --dry-run
+```
+
+Stream output directly. If the output contains `No tickets found` or a preflight error (`✗`), stop — there is nothing to do.
+
+### 2b. Feasibility evaluation
+
+Read the ticket title and description from the dry-run output. Evaluate whether this ticket can be implemented entirely as code changes committed to a git repository.
+
+The ticket is **infeasible** if it requires ANY of:
+- Manual testing or configuration in external tools or admin panels
+- Access to external services, APIs, or platforms not available in the codebase
+- Physical, hardware, or infrastructure changes
+- Design assets that do not yet exist
+- Deployment or infrastructure changes outside the repository
+- Human judgment calls that require stakeholder input
+
+If the ticket is infeasible, display:
+```
+⏭️ {TICKET-KEY} skipped — {one-line reason}.
+
+"Not on my watch." — The ticket requires work that Clancy can't do as code changes. A human should handle this one.
+```
+Stop here.
+
+### 2c. Execute
+
+If the ticket is feasible, run the full lifecycle (skipping the script's built-in feasibility check since we just evaluated it):
+```bash
+node .clancy/clancy-once.js --skip-feasibility
 ```
 
 Stream output directly — do not buffer or summarise.


### PR DESCRIPTION
## Summary

- The `claude -p` call in the feasibility check created a blocked nested session when running inside Claude Code via `/clancy:once`
- The workflow now runs a dry-run first to fetch ticket details, evaluates feasibility directly (no subprocess), then runs the script with `--skip-feasibility`
- The script-level `claude -p` check is preserved for standalone/AFK mode where it works correctly
- Ticket description is now included in dry-run output for the workflow to evaluate

## Test plan

- [x] 161 unit tests passing (new test for `--skip-feasibility` flag)
- [x] Typecheck clean
- [x] Lint clean
- [x] Run `/clancy:once` inside Claude Code — should no longer hit nesting error
- [x] Verify dry-run shows ticket description
- [x] Verify standalone `node .clancy/clancy-once.js` still runs feasibility check

🤖 Generated with [Claude Code](https://claude.com/claude-code)