### PR TITLE
Simplify branching strategy and automate releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 jobs:
   build-and-test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,41 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [main]
 
 jobs:
+  check-version:
+    name: Check for version bump
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.detect.outputs.version }}
+      tag: ${{ steps.detect.outputs.tag }}
+      changed: ${{ steps.detect.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect version change
+        id: detect
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+          if git rev-parse "${TAG}" >/dev/null 2>&1; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Tag ${TAG} already exists — no release needed."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "New version detected: ${VERSION}"
+          fi
+
   release:
+    name: Tag, build, and release
+    needs: check-version
+    if: needs.check-version.outputs.changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -14,23 +44,49 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Extract changelog for this version
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: rm -rf node_modules package-lock.json && npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Create tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ needs.check-version.outputs.tag }}"
+          git push origin "${{ needs.check-version.outputs.tag }}"
+
+      - name: Extract changelog
         id: changelog
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          # Extract the section for this version from CHANGELOG.md
-          # Grabs everything between ## [VERSION] and the next ## heading
+          VERSION="${{ needs.check-version.outputs.version }}"
           NOTES=$(awk "/^## \[${VERSION}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
           if [ -z "$NOTES" ]; then
             NOTES="See [CHANGELOG.md](./CHANGELOG.md) for details."
           fi
-          # Write to file to avoid quoting issues with multiline strings
           echo "$NOTES" > release-notes.txt
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --title "$GITHUB_REF_NAME" \
-            --notes-file release-notes.txt
+          TAG="${{ needs.check-version.outputs.tag }}"
+          IS_PRERELEASE=false
+          if echo "$TAG" | grep -qE '(alpha|beta|rc)'; then
+            IS_PRERELEASE=true
+          fi
+
+          PRERELEASE_FLAG=""
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file release-notes.txt \
+            $PRERELEASE_FLAG

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,21 +52,14 @@ Examples:
 See [docs/GIT.md](docs/GIT.md) for full details. Summary:
 
 - `main` — production. Tagged releases. Never commit directly.
-- `develop` — integration branch. Never commit directly.
-- `feature/`, `fix/`, `chore/` — branch from `develop`
-- `hotfix/` — branch from `main` for urgent production fixes
-- `release/` — branch from `develop` for release prep
+- `feature/`, `fix/`, `chore/` — branch from `main`, PR back to `main`
 
 ## Release checklist
 
-1. Create `release/vX.Y.Z` from `develop`
-2. Update `CHANGELOG.md` with the new version entry
-3. Bump version in `package.json`
-4. Merge release branch to `main`
-5. Tag and push: `git tag vX.Y.Z && git push origin vX.Y.Z`
-6. Verify the GitHub Actions release workflow completed
-7. Publish to npm: `npm publish` (or `npm publish --tag beta` for pre-releases)
-8. Merge `main` back into `develop`
+1. Include version bump (`package.json`) and `CHANGELOG.md` entry in the PR
+2. Squash merge PR to `main`
+3. GitHub Actions automatically: creates tag → builds → creates GitHub Release
+4. Publish to npm: `npm publish` (or `npm publish --tag beta` for pre-releases)
 
 ## Important technical details
 

--- a/docs/GIT.md
+++ b/docs/GIT.md
@@ -3,29 +3,26 @@
 ## Branch Strategy
 
 ```
-main ← release/vX.Y.Z ← develop ← feature/ | fix/ | chore/
-main ← hotfix/vX.Y.Z
+main ← feature/ | fix/ | chore/
 ```
+
+All work branches from `main` and merges back to `main` via PR.
 
 ### Branches
 
 | Branch | Purpose | Branched from | Merges into |
 |---|---|---|---|
 | `main` | Production code, tagged releases | — | — |
-| `develop` | Integration branch | `main` (once) | — |
-| `feature/<name>` | New features | `develop` | `develop` |
-| `fix/<name>` | Bug fixes | `develop` | `develop` |
-| `chore/<name>` | Maintenance, deps, config | `develop` | `develop` |
-| `hotfix/vX.Y.Z` | Urgent production fixes | `main` | `main` + `develop` |
-| `release/vX.Y.Z` | Release preparation | `develop` | `main` + `develop` |
+| `feature/<name>` | New features | `main` | `main` |
+| `fix/<name>` | Bug fixes | `main` | `main` |
+| `chore/<name>` | Maintenance, deps, config | `main` | `main` |
 
 ### Rules
 
-- Never commit directly to `main` or `develop`
+- Never commit directly to `main`
 - All work goes through a branch and a PR
 - Delete branches after merging
-- Hotfixes merge into both `main` and `develop`
-- Release branches merge into both `main` and `develop`
+- CI must pass before merging
 
 ## Branch Naming
 
@@ -33,7 +30,7 @@ main ← hotfix/vX.Y.Z
 type/short-description
 ```
 
-Types: `feature`, `fix`, `chore`, `hotfix`, `release`
+Types: `feature`, `fix`, `chore`
 
 Examples:
 
@@ -41,8 +38,6 @@ Examples:
 feature/context-monitor
 fix/push-protection-test-values
 chore/update-dependencies
-hotfix/v0.2.1
-release/v0.3.0
 ```
 
 Keep names short and descriptive. No ticket numbers (Clancy doesn't use an external board for its own development).
@@ -86,23 +81,32 @@ The gitmoji comes first, then the conventional commit type. Scope is optional.
 
 ## Merge Strategy
 
-- Feature/fix/chore branches: squash merge into `develop`
-- Release branches: merge commit into `main` (preserves release history)
-- Hotfix branches: merge commit into both `main` and `develop`
+- Feature/fix/chore branches: **squash merge** into `main`
 
 ## Release Flow
 
-1. Branch `release/vX.Y.Z` from `develop`
-2. Update `CHANGELOG.md` and `package.json` version
-3. PR into `main`, merge
-4. Tag: `git tag vX.Y.Z && git push origin vX.Y.Z`
-5. GitHub Actions creates the release automatically
-6. Publish: `npm publish` (or `npm publish --tag beta`)
-7. Merge `main` back into `develop`
+### Stable releases
+
+1. Include version bump (`package.json`) and `CHANGELOG.md` entry in your PR
+2. Squash merge PR to `main`
+3. GitHub Actions automatically: creates tag → builds → creates GitHub Release
+4. Publish to npm: `npm publish`
+
+That's it. Tagging, building, and the GitHub Release are fully automated.
+
+### Beta / pre-releases
+
+1. Bump to a pre-release version in your branch (e.g. `0.4.0-beta.1`)
+2. Add a CHANGELOG entry under `## [0.4.0-beta.1]`
+3. Squash merge PR to `main`
+4. GitHub Actions creates tag `v0.4.0-beta.1` and marks the release as a pre-release
+5. Publish: `npm publish --tag beta`
+6. Users install with: `npx chief-clancy@beta`
+7. When ready for stable: bump to `0.4.0`, merge, automation tags, publish normally
 
 ## Tagging
 
 - Tags follow semver: `vMAJOR.MINOR.PATCH`
 - Pre-release tags: `vMAJOR.MINOR.PATCH-beta.N`
-- Tag after merging to `main`, before npm publish — always
-- Pushing a tag triggers the GitHub Actions release workflow
+- Tags are created automatically by GitHub Actions when a version bump is detected on `main`
+- Pushing a tag triggers the release workflow (build + GitHub Release)


### PR DESCRIPTION
## Summary

- Drop `develop` and `release/` branches — linear strategy where feature/fix/chore branches PR directly to `main`
- GitHub Actions now auto-creates tags and GitHub Releases when a version bump is detected on `main`
- Pre-release versions (beta/alpha/rc) are automatically marked as pre-releases on GitHub
- CI workflow updated to only target `main` (removed `develop` from PR triggers)
- Updated `docs/GIT.md`, `CLAUDE.md` with simplified strategy and release flow

## How releases work now

1. Include version bump + CHANGELOG entry in your PR
2. Squash merge to main
3. **Automation**: detects new version → creates tag → builds → creates GitHub Release
4. You run `npm publish` (only manual step)

## Beta releases

1. Bump to `0.4.0-beta.1` in the PR
2. Merge to main → auto-tagged as `v0.4.0-beta.1`, marked as pre-release
3. Publish with `npm publish --tag beta`

## GitHub repo settings needed after merge

- Add branch protection to `main`: require PR, require CI to pass
- Archive or delete `develop` branch

## Test plan

- [x] 161 unit tests passing
- [ ] Merge this PR and verify auto-tag + release workflow triggers
- [ ] Verify pre-release detection works (future beta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)