### PR TITLE
Add .prettierignore handling during init and uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ---
 
+## [0.3.8] — 2026-03-12
+
+### ✨ Features
+
+- **Prettier ignore handling** — During init, if a `.prettierignore` file exists, Clancy now appends `.clancy/` and `.claude/commands/clancy/` to prevent Prettier from reformatting generated files. On uninstall, those entries are cleanly removed. Projects without Prettier are unaffected.
+
+---
+
 ## [0.3.7] — 2026-03-12
 
 ### 🐛 Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chief-clancy",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chief-clancy",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "MIT",
       "bin": {
         "clancy": "dist/installer/install.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chief-clancy",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Autonomous, board-driven development for Claude Code — scaffolds docs, integrates Kanban boards, runs tickets in a loop.",
   "keywords": [
     "claude",

--- a/src/workflows/scaffold.md
+++ b/src/workflows/scaffold.md
@@ -290,6 +290,21 @@ node_modules/
 
 ---
 
+## .prettierignore check
+
+Check whether a `.prettierignore` file exists in the project root.
+
+**If it exists:** read it. If it does not already contain `.clancy/`, append:
+```
+# Clancy generated files
+.clancy/
+.claude/commands/clancy/
+```
+
+**If it does not exist:** skip — do not create it. Clancy only adds entries to an existing `.prettierignore` so it does not impose Prettier on projects that don't use it.
+
+---
+
 ## Runtime scripts
 
 The installer copies bundled runtime scripts (`clancy-once.js` and `clancy-afk.js`) directly into `.clancy/` during installation. These are self-contained — they have zero runtime dependency on the `chief-clancy` npm package.

--- a/src/workflows/uninstall.md
+++ b/src/workflows/uninstall.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Remove Clancy's slash commands from the local project, globally, or both. Optionally remove the `.clancy/` project folder (which includes `.clancy/.env`). Clean up CLAUDE.md and .gitignore changes made during init.
+Remove Clancy's slash commands from the local project, globally, or both. Optionally remove the `.clancy/` project folder (which includes `.clancy/.env`). Clean up CLAUDE.md, .gitignore, and .prettierignore changes made during init.
 
 ---
 
@@ -108,7 +108,25 @@ Print `✅ .gitignore cleaned up.` (or `✅ .gitignore removed.` if deleted).
 
 ---
 
-## Step 5 — Offer to remove .clancy/ (if present)
+## Step 5 — Clean up .prettierignore
+
+Check whether `.prettierignore` exists in the current project directory.
+
+If it does, check whether it contains Clancy entries (`# Clancy generated files` and/or `.clancy/` and/or `.claude/commands/clancy/`):
+
+**If found:** remove the `# Clancy generated files` comment line, the `.clancy/` line, and the `.claude/commands/clancy/` line. Also remove any blank line immediately before or after the removed block to avoid leaving double blank lines. Write the cleaned file back.
+
+If the file is now empty (or contains only whitespace) after removal, delete it entirely — Clancy added those entries during init.
+
+Print `✅ .prettierignore cleaned up.` (or `✅ .prettierignore removed.` if deleted).
+
+**If not found:** skip — Clancy didn't modify this file.
+
+**If .prettierignore does not exist:** skip.
+
+---
+
+## Step 6 — Offer to remove .clancy/ (if present)
 
 Check whether `.clancy/` exists in the current project directory.
 
@@ -126,7 +144,7 @@ If `.clancy/` does not exist, skip this step entirely.
 
 ---
 
-## Step 6 — Final message
+## Step 7 — Final message
 
 ```
 ✅ Clancy uninstalled.
@@ -138,6 +156,6 @@ If `.clancy/` does not exist, skip this step entirely.
 
 ## Hard constraints
 
-- **Never touch any `.env` at the project root** — Clancy's credentials live in `.clancy/.env` and are only removed as part of `.clancy/` in Step 5
-- Steps 1–2 (commands removal), Steps 3–4 (CLAUDE.md and .gitignore cleanup), and Step 5 (`.clancy/` removal) are always asked separately — never bundle them into one confirmation
+- **Never touch any `.env` at the project root** — Clancy's credentials live in `.clancy/.env` and are only removed as part of `.clancy/` in Step 6
+- Steps 1–2 (commands removal), Steps 3–5 (CLAUDE.md, .gitignore, and .prettierignore cleanup), and Step 6 (`.clancy/` removal) are always asked separately — never bundle them into one confirmation
 - If the user says no to commands removal in Step 2, skip all remaining steps and stop


### PR DESCRIPTION
## Summary

- During init, if `.prettierignore` exists, append `.clancy/` and `.claude/commands/clancy/` to prevent Prettier from reformatting generated files
- On uninstall, remove those entries cleanly (and delete the file if it becomes empty)
- Projects without Prettier are unaffected — Clancy only modifies an existing `.prettierignore`, never creates one

Fixes the lint-staged/prettier errors seen when Clancy scaffolds files into projects with Prettier configured.

## Test plan

- [x] Run `/clancy:init` on a project with `.prettierignore` — verify entries are added
- [x] Run `/clancy:init` on a project without `.prettierignore` — verify no file is created
- [x] Run `/clancy:uninstall` — verify entries are removed
- [x] Run `/clancy:uninstall` on a project where Clancy was the only `.prettierignore` content — verify file is deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)