### PR TITLE
♻️ refactor: fetchAndParse<T>() utility + GitHub/Jira conversion (PR 1a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Headers: `✨ Features`, `🐛 Fixes`, `♻️ Refactors`, `✅ Tests`, `📝 Do
 
 ---
 
+## [0.8.24] — 2026-03-23
+
+### ♻️ Refactors
+
+- **`fetchAndParse<T>()` shared utility** — generic fetch → JSON → Zod validation helper in `src/scripts/shared/http/fetch-and-parse.ts`. Eliminates the repeated try/fetch/check-ok/parse-json/validate-zod boilerplate. Returns parsed data or `undefined` on any failure (network, HTTP status, invalid JSON, schema mismatch). All failures logged with a configurable label. 8 new unit tests.
+- **GitHub board: use `fetchAndParse`** — converted `fetchIssues()` to use the shared utility. Removed ~25 lines of boilerplate.
+- **Jira board: use `fetchAndParse`** — converted `fetchTickets()` and `lookupTransitionId()` to use the shared utility. Removed ~45 lines of boilerplate.
+
+---
+
 ## [0.8.23] — 2026-03-23
 
 ### 📝 Docs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Autonomous, board-driven development for Claude Code.**
 
-[![npm](https://img.shields.io/npm/v/chief-clancy?style=for-the-badge&color=cb3837)](https://www.npmjs.com/package/chief-clancy) [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=for-the-badge)](./LICENSE) [![CI](https://github.com/Pushedskydiver/clancy/actions/workflows/ci.yml/badge.svg)](https://github.com/Pushedskydiver/clancy/actions/workflows/ci.yml) [![GitHub Stars](https://img.shields.io/github/stars/Pushedskydiver/clancy?style=for-the-badge)](https://github.com/Pushedskydiver/clancy/stargazers)
+[![npm](https://img.shields.io/npm/v/chief-clancy?style=for-the-badge&color=cb3837)](https://www.npmjs.com/package/chief-clancy) [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=for-the-badge)](./LICENSE) [![CI](https://img.shields.io/github/actions/workflow/status/Pushedskydiver/clancy/ci.yml?style=for-the-badge&label=CI)](https://github.com/Pushedskydiver/clancy/actions/workflows/ci.yml) [![GitHub Stars](https://img.shields.io/github/stars/Pushedskydiver/clancy?style=for-the-badge)](https://github.com/Pushedskydiver/clancy/stargazers)
 
 > [!WARNING]
 > Clancy is in early development. Expect bugs, breaking changes, and rough edges. If you hit an issue, please [open a bug report](https://github.com/Pushedskydiver/clancy/issues/new).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chief-clancy",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chief-clancy",
-      "version": "0.8.23",
+      "version": "0.8.24",
       "license": "MIT",
       "bin": {
         "clancy": "dist/installer/install.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chief-clancy",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "description": "Autonomous, board-driven development for Claude Code — scaffolds docs, integrates Kanban boards, runs tickets in a loop.",
   "keywords": [
     "claude",

--- a/src/scripts/board/github/github.ts
+++ b/src/scripts/board/github/github.ts
@@ -10,6 +10,7 @@
 import { z } from 'zod/mini';
 
 import { githubIssuesResponseSchema } from '~/schemas/github.js';
+import { fetchAndParse } from '~/scripts/shared/http/fetch-and-parse.js';
 import {
   GITHUB_API,
   githubHeaders,
@@ -162,8 +163,6 @@ export async function fetchIssues(
   excludeHitl?: boolean,
   limit = 5,
 ): Promise<GitHubTicket[]> {
-  let response: Response;
-
   const params = new URLSearchParams({
     state: 'open',
     assignee: username ?? '@me',
@@ -172,40 +171,16 @@ export async function fetchIssues(
 
   if (label) params.set('labels', label);
 
-  try {
-    response = await fetch(`${GITHUB_API}/repos/${repo}/issues?${params}`, {
-      headers: githubHeaders(token),
-    });
-  } catch (err) {
-    console.warn(
-      `⚠ GitHub API request failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return [];
-  }
+  const data = await fetchAndParse(
+    `${GITHUB_API}/repos/${repo}/issues?${params}`,
+    { headers: githubHeaders(token) },
+    { schema: githubIssuesResponseSchema, label: 'GitHub Issues API' },
+  );
 
-  if (!response.ok) {
-    console.warn(`⚠ GitHub API returned HTTP ${response.status}`);
-    return [];
-  }
-
-  let json: unknown;
-
-  try {
-    json = await response.json();
-  } catch {
-    console.warn('⚠ GitHub API returned invalid JSON');
-    return [];
-  }
-
-  const parsed = githubIssuesResponseSchema.safeParse(json);
-
-  if (!parsed.success) {
-    console.warn(`⚠ Unexpected GitHub response shape: ${parsed.error.message}`);
-    return [];
-  }
+  if (!data) return [];
 
   // Filter out pull requests
-  let issues = parsed.data.filter((item) => !item.pull_request);
+  let issues = data.filter((item) => !item.pull_request);
 
   // HITL/AFK filtering: exclude issues with clancy:hitl label
   // GitHub Issues API doesn't support label exclusion natively, so filter client-side.

--- a/src/scripts/board/jira/jira.ts
+++ b/src/scripts/board/jira/jira.ts
@@ -12,6 +12,7 @@ import {
   jiraSearchResponseSchema,
   jiraTransitionsResponseSchema,
 } from '~/schemas/jira.js';
+import { fetchAndParse } from '~/scripts/shared/http/fetch-and-parse.js';
 import { jiraHeaders, pingEndpoint } from '~/scripts/shared/http/http.js';
 import type { PingResult } from '~/scripts/shared/http/http.js';
 import type { Ticket } from '~/types/index.js';
@@ -205,10 +206,9 @@ export async function fetchTickets(
 ): Promise<JiraTicket[]> {
   const jql = buildJql(projectKey, status, sprint, label, excludeHitl);
 
-  let response: Response;
-
-  try {
-    response = await fetch(`${baseUrl}/rest/api/3/search/jql`, {
+  const data = await fetchAndParse(
+    `${baseUrl}/rest/api/3/search/jql`,
+    {
       method: 'POST',
       headers: {
         ...jiraHeaders(auth),
@@ -226,36 +226,13 @@ export async function fetchTickets(
           'labels',
         ],
       }),
-    });
-  } catch (err) {
-    console.warn(
-      `⚠ Jira API request failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return [];
-  }
+    },
+    { schema: jiraSearchResponseSchema, label: 'Jira API' },
+  );
 
-  if (!response.ok) {
-    console.warn(`⚠ Jira API returned HTTP ${response.status}`);
-    return [];
-  }
+  if (!data) return [];
 
-  let json: unknown;
-
-  try {
-    json = await response.json();
-  } catch {
-    console.warn('⚠ Jira API returned invalid JSON');
-    return [];
-  }
-
-  const parsed = jiraSearchResponseSchema.safeParse(json);
-
-  if (!parsed.success) {
-    console.warn(`⚠ Unexpected Jira response shape: ${parsed.error.message}`);
-    return [];
-  }
-
-  return parsed.data.issues.map((issue) => {
+  return data.issues.map((issue) => {
     const fields = issue.fields;
 
     // Extract blockers
@@ -439,43 +416,13 @@ export async function lookupTransitionId(
 ): Promise<string | undefined> {
   if (!ISSUE_KEY_PATTERN.test(issueKey)) return undefined;
 
-  let response: Response;
+  const data = await fetchAndParse(
+    `${baseUrl}/rest/api/3/issue/${issueKey}/transitions`,
+    { headers: jiraHeaders(auth) },
+    { schema: jiraTransitionsResponseSchema, label: 'Jira transitions' },
+  );
 
-  try {
-    response = await fetch(
-      `${baseUrl}/rest/api/3/issue/${issueKey}/transitions`,
-      { headers: jiraHeaders(auth) },
-    );
-  } catch (err) {
-    console.warn(
-      `⚠ Jira transitions request failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return undefined;
-  }
-
-  if (!response.ok) return undefined;
-
-  let json: unknown;
-
-  try {
-    json = await response.json();
-  } catch {
-    console.warn('⚠ Jira transitions returned invalid JSON');
-    return undefined;
-  }
-
-  const parsed = jiraTransitionsResponseSchema.safeParse(json);
-
-  if (!parsed.success) {
-    console.warn(
-      `⚠ Unexpected Jira transitions response: ${parsed.error.message}`,
-    );
-    return undefined;
-  }
-
-  const transition = parsed.data.transitions.find((t) => t.name === statusName);
-
-  return transition?.id;
+  return data?.transitions.find((t) => t.name === statusName)?.id;
 }
 
 /**

--- a/src/scripts/shared/http/fetch-and-parse.test.ts
+++ b/src/scripts/shared/http/fetch-and-parse.test.ts
@@ -63,6 +63,55 @@ describe('fetchAndParse', () => {
     );
   });
 
+  it('includes response body snippet in non-OK warning', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Bad credentials', { status: 401 }),
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await fetchAndParse('https://api.example.com/auth', undefined, {
+      schema: testSchema,
+      label,
+    });
+
+    const message = warn.mock.calls[0][0] as string;
+    expect(message).toContain('returned HTTP 401');
+    expect(message).toContain('Bad credentials');
+  });
+
+  it('truncates long response bodies to 200 chars', async () => {
+    const longBody = 'X'.repeat(1000);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(longBody, { status: 500 }),
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await fetchAndParse('https://api.example.com/error', undefined, {
+      schema: testSchema,
+      label,
+    });
+
+    const message = warn.mock.calls[0][0] as string;
+    expect(message).toContain('returned HTTP 500');
+    expect(message).not.toContain(longBody);
+    expect(message.length).toBeLessThan(300);
+  });
+
+  it('omits body segment when response body is empty', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 404 }),
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await fetchAndParse('https://api.example.com/empty', undefined, {
+      schema: testSchema,
+      label,
+    });
+
+    const message = warn.mock.calls[0][0] as string;
+    expect(message).toBe(`⚠ ${label} returned HTTP 404`);
+  });
+
   it('returns undefined on invalid JSON', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response('not json', {

--- a/src/scripts/shared/http/fetch-and-parse.test.ts
+++ b/src/scripts/shared/http/fetch-and-parse.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/mini';
+
+import { fetchAndParse } from './fetch-and-parse.js';
+
+const testSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+});
+
+const label = 'Test API';
+
+describe('fetchAndParse', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns parsed data on success', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: 1, name: 'Alice' }), { status: 200 }),
+    );
+
+    const result = await fetchAndParse(
+      'https://api.example.com/users/1',
+      undefined,
+      { schema: testSchema, label },
+    );
+
+    expect(result).toEqual({ id: 1, name: 'Alice' });
+  });
+
+  it('returns undefined on network error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await fetchAndParse(
+      'https://api.example.com/down',
+      undefined,
+      { schema: testSchema, label },
+    );
+
+    expect(result).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('request failed: ECONNREFUSED'),
+    );
+  });
+
+  it('returns undefined on non-OK status', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Unauthorized', { status: 401 }),
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await fetchAndParse(
+      'https://api.example.com/secret',
+      undefined,
+      { schema: testSchema, label },
+    );
+
+    expect(result).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('returned HTTP 401'),
+    );
+  });
+
+  it('returns undefined on invalid JSON', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('not json', {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+      }),
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await fetchAndParse(
+      'https://api.example.com/broken',
+      undefined,
+      { schema: testSchema, label },
+    );
+
+    expect(result).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('returned invalid JSON'),
+    );
+  });
+
+  it('returns undefined on schema mismatch', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ wrong: 'shape' }), { status: 200 }),
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await fetchAndParse(
+      'https://api.example.com/mismatched',
+      undefined,
+      { schema: testSchema, label },
+    );
+
+    expect(result).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('unexpected response shape'),
+    );
+  });
+
+  it('passes init options to fetch', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ id: 1, name: 'Bob' }), { status: 200 }),
+      );
+
+    await fetchAndParse(
+      'https://api.example.com/data',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: 'test' }),
+      },
+      { schema: testSchema, label },
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.example.com/data',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('includes label in all error messages', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('timeout'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await fetchAndParse('https://api.example.com', undefined, {
+      schema: testSchema,
+      label: 'Custom Board API',
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Custom Board API'),
+    );
+  });
+
+  it('handles non-Error throw from fetch', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue('string error');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await fetchAndParse('https://api.example.com', undefined, {
+      schema: testSchema,
+      label,
+    });
+
+    expect(result).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('string error'));
+  });
+});

--- a/src/scripts/shared/http/fetch-and-parse.ts
+++ b/src/scripts/shared/http/fetch-and-parse.ts
@@ -1,0 +1,80 @@
+/**
+ * Generic fetch → parse → validate utility.
+ *
+ * Eliminates the repeated try/fetch/check-ok/parse-json/validate-zod
+ * boilerplate across board modules. Scoped to single HTTP requests with
+ * JSON responses validated by a Zod schema.
+ *
+ * Boards with pagination (Notion), multi-step fetches (Azure DevOps),
+ * or deep response unwrapping (Linear) keep their own wrappers that
+ * call this function internally.
+ */
+import type { ZodMiniType } from 'zod/mini';
+
+/** Options for {@link fetchAndParse}. */
+export type FetchAndParseOptions<T> = {
+  /** Zod schema to validate the response body against. */
+  schema: ZodMiniType<T>;
+  /** Human-readable label for error messages (e.g., `'Jira API'`). */
+  label: string;
+};
+
+/**
+ * Fetch a URL, parse the JSON response, and validate it against a Zod schema.
+ *
+ * Returns the parsed data on success, or `undefined` on any failure
+ * (network error, non-OK status, invalid JSON, schema mismatch).
+ * All failures are logged to `console.warn` with the provided label.
+ *
+ * @param url - The URL to fetch.
+ * @param init - Standard `fetch` RequestInit options.
+ * @param opts - Schema and label for validation and error messages.
+ * @returns The parsed and validated data, or `undefined` on failure.
+ */
+export async function fetchAndParse<T>(
+  url: string,
+  init: RequestInit | undefined,
+  opts: FetchAndParseOptions<T>,
+): Promise<T | undefined> {
+  const { schema, label } = opts;
+
+  let response: Response;
+  try {
+    response = await fetch(url, init);
+  } catch (err) {
+    console.warn(
+      `⚠ ${label} request failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return undefined;
+  }
+
+  if (!response.ok) {
+    let detail = '';
+    try {
+      const body = await response.text();
+      if (body) detail = ` — ${body.slice(0, 200)}`;
+    } catch {
+      // ignore body read failure
+    }
+    console.warn(`⚠ ${label} returned HTTP ${response.status}${detail}`);
+    return undefined;
+  }
+
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch {
+    console.warn(`⚠ ${label} returned invalid JSON`);
+    return undefined;
+  }
+
+  const parsed = schema.safeParse(json);
+  if (!parsed.success) {
+    console.warn(
+      `⚠ ${label} unexpected response shape: ${parsed.error.message}`,
+    );
+    return undefined;
+  }
+
+  return parsed.data;
+}


### PR DESCRIPTION
## Summary

First PR of the code quality epic. Introduces the shared `fetchAndParse<T>()` utility and converts the two simplest boards.

- **`fetchAndParse<T>()`** (`src/scripts/shared/http/fetch-and-parse.ts`) — generic fetch → JSON → Zod validation. Returns parsed data or `undefined` on failure. Logs with configurable label. Includes truncated response body in error messages for diagnostics. 8 unit tests.
- **GitHub**: converted `fetchIssues()` — removed ~25 lines of boilerplate
- **Jira**: converted `fetchTickets()` and `lookupTransitionId()` — removed ~45 lines of boilerplate

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 1255 unit tests pass (+8 new)
- [x] `npm run test:integration` — 238 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)