### PR TITLE
♻️ refactor: fetchAndParse — Linear, Shortcut, Notion, Azure DevOps (PR 1b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Headers: `✨ Features`, `🐛 Fixes`, `♻️ Refactors`, `✅ Tests`, `📝 Do
 - **`fetchAndParse<T>()` shared utility** — generic fetch → JSON → Zod validation helper in `src/scripts/shared/http/fetch-and-parse.ts`. Eliminates the repeated try/fetch/check-ok/parse-json/validate-zod boilerplate. Returns parsed data or `undefined` on any failure (network, HTTP status, invalid JSON, schema mismatch). All failures logged with a configurable label. 8 new unit tests.
 - **GitHub board: use `fetchAndParse`** — converted `fetchIssues()` to use the shared utility. Removed ~25 lines of boilerplate.
 - **Jira board: use `fetchAndParse`** — converted `fetchTickets()` and `lookupTransitionId()` to use the shared utility. Removed ~45 lines of boilerplate.
+- **`fetchAndParse` custom fetcher** — optional `fetcher` param for boards that need custom fetch functions (e.g., Notion's `retryFetch` for rate limits). 3 new unit tests.
+- **Linear board: use `fetchAndParse`** — converted `fetchIssues()`, `fetchBlockerStatus()`, `lookupWorkflowStateId()`, `executeStateTransition()`, `fetchChildrenByDescription()`. Added `linearInit()` helper to build GraphQL requests. Removed ~35 lines of boilerplate.
+- **Shortcut board: use `fetchAndParse`** — converted `fetchWorkflows()`, `fetchLabels()`, `createLabel()`, `fetchStory()`, `getStoryLabelIds()`. Removed ~75 lines of boilerplate.
+- **Notion board: use `fetchAndParse`** — converted `queryDatabase()` and `fetchPage()` using the custom `fetcher` param with `retryFetch`. Removed ~30 lines of boilerplate.
+- **Azure DevOps board: use `fetchAndParse`** — converted `runWiql()`, `fetchWorkItem()`, `fetchChildrenByLinks()`. Removed ~40 lines of boilerplate.
 
 ---
 

--- a/src/scripts/board/azdo/azdo.ts
+++ b/src/scripts/board/azdo/azdo.ts
@@ -15,6 +15,7 @@ import {
   azdoWorkItemsBatchResponseSchema,
 } from '~/schemas/azdo.js';
 import type { AzdoWorkItem } from '~/schemas/azdo.js';
+import { fetchAndParse } from '~/scripts/shared/http/fetch-and-parse.js';
 import type { Ticket } from '~/types/index.js';
 
 const API_VERSION = '7.1';
@@ -160,38 +161,17 @@ export async function runWiql(
   pat: string,
   query: string,
 ): Promise<number[]> {
-  try {
-    const response = await fetch(
-      `${apiBase(org, project)}/wit/wiql?api-version=${API_VERSION}`,
-      {
-        method: 'POST',
-        headers: azdoHeaders(pat),
-        body: JSON.stringify({ query }),
-      },
-    );
+  const data = await fetchAndParse(
+    `${apiBase(org, project)}/wit/wiql?api-version=${API_VERSION}`,
+    {
+      method: 'POST',
+      headers: azdoHeaders(pat),
+      body: JSON.stringify({ query }),
+    },
+    { schema: azdoWiqlResponseSchema, label: 'Azure DevOps WIQL' },
+  );
 
-    if (!response.ok) {
-      console.warn(`⚠ Azure DevOps WIQL returned HTTP ${response.status}`);
-      return [];
-    }
-
-    const json: unknown = await response.json();
-    const parsed = azdoWiqlResponseSchema.safeParse(json);
-
-    if (!parsed.success) {
-      console.warn(
-        `⚠ Unexpected Azure DevOps WIQL response: ${parsed.error.message}`,
-      );
-      return [];
-    }
-
-    return parsed.data.workItems.map((wi) => wi.id);
-  } catch (err) {
-    console.warn(
-      `⚠ Azure DevOps WIQL request failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return [];
-  }
+  return data ? data.workItems.map((wi) => wi.id) : [];
 }
 
 /**
@@ -267,23 +247,11 @@ export async function fetchWorkItem(
   pat: string,
   id: number,
 ): Promise<AzdoWorkItem | undefined> {
-  try {
-    const response = await fetch(
-      `${apiBase(org, project)}/wit/workitems/${id}?$expand=relations&api-version=${API_VERSION}`,
-      { headers: azdoHeaders(pat) },
-    );
-
-    if (!response.ok) return undefined;
-
-    const json: unknown = await response.json();
-    const parsed = azdoWorkItemSchema.safeParse(json);
-
-    if (!parsed.success) return undefined;
-
-    return parsed.data;
-  } catch {
-    return undefined;
-  }
+  return await fetchAndParse(
+    `${apiBase(org, project)}/wit/workitems/${id}?$expand=relations&api-version=${API_VERSION}`,
+    { headers: azdoHeaders(pat) },
+    { schema: azdoWorkItemSchema, label: 'Azure DevOps work item' },
+  );
 }
 
 /** A JSON Patch operation for Azure DevOps work item updates. */
@@ -612,23 +580,19 @@ async function fetchChildrenByLinks(
     if (Number.isNaN(parentId)) return undefined;
     const wiql = `SELECT [System.Id] FROM WorkItemLinks WHERE [Source].[System.Id] = ${parentId} AND [System.Links.LinkType] = 'System.LinkTypes.Hierarchy-Forward' MODE (MustContain)`;
 
-    const response = await fetch(
+    const data = await fetchAndParse(
       `${apiBase(org, project)}/wit/wiql?api-version=${API_VERSION}`,
       {
         method: 'POST',
         headers: azdoHeaders(pat),
         body: JSON.stringify({ query: wiql }),
       },
+      { schema: azdoWiqlLinkResponseSchema, label: 'Azure DevOps WIQL links' },
     );
 
-    if (!response.ok) return undefined;
+    if (!data) return undefined;
 
-    const json: unknown = await response.json();
-    const parsed = azdoWiqlLinkResponseSchema.safeParse(json);
-
-    if (!parsed.success) return undefined;
-
-    const relations = parsed.data.workItemRelations ?? [];
+    const relations = data.workItemRelations ?? [];
     // Filter out the source item itself (target is null for the source row)
     const childIds = relations
       .filter((r) => r.target?.id !== undefined && r.target.id !== parentId)

--- a/src/scripts/board/linear/linear.ts
+++ b/src/scripts/board/linear/linear.ts
@@ -376,7 +376,9 @@ async function fetchChildrenByDescription(
     { schema: linearIssueSearchResponseSchema, label: 'Linear issue search' },
   );
 
-  const nodes = data?.data?.issueSearch?.nodes ?? [];
+  if (!data) return undefined;
+
+  const nodes = data.data?.issueSearch?.nodes ?? [];
   const total = nodes.length;
   const doneTypes = new Set(['completed', 'canceled']);
   const incomplete = nodes.filter(

--- a/src/scripts/board/linear/linear.ts
+++ b/src/scripts/board/linear/linear.ts
@@ -15,10 +15,27 @@ import {
   linearViewerResponseSchema,
   linearWorkflowStatesResponseSchema,
 } from '~/schemas/linear.js';
+import { fetchAndParse } from '~/scripts/shared/http/fetch-and-parse.js';
 import type { Ticket } from '~/types/index.js';
 
 const SAFE_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const LINEAR_API_URL = 'https://api.linear.app/graphql';
+
+/** Build standard Linear GraphQL request init. */
+function linearInit(
+  apiKey: string,
+  query: string,
+  variables?: Record<string, unknown>,
+): RequestInit {
+  return {
+    method: 'POST',
+    headers: {
+      Authorization: apiKey,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, variables }),
+  };
+}
 
 type LinearEnv = {
   LINEAR_API_KEY: string;
@@ -219,15 +236,13 @@ export async function fetchIssues(
 
   if (hasLabel) variables.label = label;
 
-  const raw = await linearGraphql(env.LINEAR_API_KEY, query, variables);
-  const parsed = linearIssuesResponseSchema.safeParse(raw);
+  const data = await fetchAndParse(
+    LINEAR_API_URL,
+    linearInit(env.LINEAR_API_KEY, query, variables),
+    { schema: linearIssuesResponseSchema, label: 'Linear issues' },
+  );
 
-  if (!parsed.success) {
-    console.warn(`⚠ Unexpected Linear response shape: ${parsed.error.message}`);
-    return [];
-  }
-
-  let nodes = parsed.data.data?.viewer?.assignedIssues?.nodes;
+  let nodes = data?.data?.viewer?.assignedIssues?.nodes;
 
   if (!nodes?.length) return [];
 
@@ -283,12 +298,16 @@ export async function fetchBlockerStatus(
     }
   `;
 
-  const raw = await linearGraphql(apiKey, query, { issueId });
-  const parsed = linearIssueRelationsResponseSchema.safeParse(raw);
+  const data = await fetchAndParse(
+    LINEAR_API_URL,
+    linearInit(apiKey, query, { issueId }),
+    {
+      schema: linearIssueRelationsResponseSchema,
+      label: 'Linear issue relations',
+    },
+  );
 
-  if (!parsed.success) return false;
-
-  const relations = parsed.data.data?.issue?.relations?.nodes ?? [];
+  const relations = data?.data?.issue?.relations?.nodes ?? [];
   const doneTypes = new Set(['completed', 'canceled']);
 
   return relations.some((rel) => {
@@ -359,12 +378,13 @@ async function fetchChildrenByDescription(
     }
   `;
 
-  const raw = await linearGraphql(apiKey, query, { filter: descriptionRef });
-  const parsed = linearIssueSearchResponseSchema.safeParse(raw);
+  const data = await fetchAndParse(
+    LINEAR_API_URL,
+    linearInit(apiKey, query, { filter: descriptionRef }),
+    { schema: linearIssueSearchResponseSchema, label: 'Linear issue search' },
+  );
 
-  if (!parsed.success) return undefined;
-
-  const nodes = parsed.data.data?.issueSearch?.nodes ?? [];
+  const nodes = data?.data?.issueSearch?.nodes ?? [];
   const total = nodes.length;
   const doneTypes = new Set(['completed', 'canceled']);
   const incomplete = nodes.filter(
@@ -447,17 +467,16 @@ export async function lookupWorkflowStateId(
     }
   `;
 
-  const raw = await linearGraphql(apiKey, query, { teamId, name: stateName });
-  const parsed = linearWorkflowStatesResponseSchema.safeParse(raw);
+  const data = await fetchAndParse(
+    LINEAR_API_URL,
+    linearInit(apiKey, query, { teamId, name: stateName }),
+    {
+      schema: linearWorkflowStatesResponseSchema,
+      label: 'Linear workflowStates',
+    },
+  );
 
-  if (!parsed.success) {
-    console.warn(
-      `⚠ Unexpected Linear workflowStates response: ${parsed.error.message}`,
-    );
-    return undefined;
-  }
-
-  return parsed.data.data?.workflowStates?.nodes?.[0]?.id;
+  return data?.data?.workflowStates?.nodes?.[0]?.id;
 }
 
 /**
@@ -481,17 +500,13 @@ export async function executeStateTransition(
     }
   `;
 
-  const raw = await linearGraphql(apiKey, mutation, { issueId, stateId });
-  const parsed = linearIssueUpdateResponseSchema.safeParse(raw);
+  const data = await fetchAndParse(
+    LINEAR_API_URL,
+    linearInit(apiKey, mutation, { issueId, stateId }),
+    { schema: linearIssueUpdateResponseSchema, label: 'Linear issueUpdate' },
+  );
 
-  if (!parsed.success) {
-    console.warn(
-      `⚠ Unexpected Linear issueUpdate response: ${parsed.error.message}`,
-    );
-    return false;
-  }
-
-  return parsed.data.data?.issueUpdate?.success === true;
+  return data?.data?.issueUpdate?.success === true;
 }
 
 /**

--- a/src/scripts/board/linear/linear.ts
+++ b/src/scripts/board/linear/linear.ts
@@ -76,14 +76,10 @@ export async function linearGraphql(
   let response: Response;
 
   try {
-    response = await fetch(LINEAR_API_URL, {
-      method: 'POST',
-      headers: {
-        Authorization: apiKey,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ query, variables }),
-    });
+    response = await fetch(
+      LINEAR_API_URL,
+      linearInit(apiKey, query, variables),
+    );
   } catch (err) {
     console.warn(
       `⚠ Linear API request failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -116,14 +112,10 @@ export async function pingLinear(
   let response: Response;
 
   try {
-    response = await fetch(LINEAR_API_URL, {
-      method: 'POST',
-      headers: {
-        Authorization: apiKey,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ query: '{ viewer { id } }' }),
-    });
+    response = await fetch(
+      LINEAR_API_URL,
+      linearInit(apiKey, '{ viewer { id } }'),
+    );
   } catch {
     return { ok: false, error: '✗ Could not reach Linear — check network' };
   }

--- a/src/scripts/board/notion/notion.ts
+++ b/src/scripts/board/notion/notion.ts
@@ -12,6 +12,7 @@ import {
   notionUserResponseSchema,
 } from '~/schemas/notion.js';
 import type { NotionPage } from '~/schemas/notion.js';
+import { fetchAndParse } from '~/scripts/shared/http/fetch-and-parse.js';
 import { retryFetch } from '~/scripts/shared/http/retry.js';
 
 const NOTION_API = 'https://api.notion.com/v1';
@@ -105,43 +106,19 @@ export async function queryDatabase(
   if (sorts) body.sorts = sorts;
   if (startCursor) body.start_cursor = startCursor;
 
-  let response: Response;
-
-  try {
-    response = await retryFetch(`${NOTION_API}/databases/${databaseId}/query`, {
+  return await fetchAndParse(
+    `${NOTION_API}/databases/${databaseId}/query`,
+    {
       method: 'POST',
       headers: notionHeaders(token),
       body: JSON.stringify(body),
-    });
-  } catch (err) {
-    console.warn(
-      `⚠ Notion API request failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return undefined;
-  }
-
-  if (!response.ok) {
-    console.warn(`⚠ Notion API returned HTTP ${response.status}`);
-    return undefined;
-  }
-
-  let json: unknown;
-
-  try {
-    json = await response.json();
-  } catch {
-    console.warn('⚠ Notion API returned invalid JSON');
-    return undefined;
-  }
-
-  const parsed = notionDatabaseQueryResponseSchema.safeParse(json);
-
-  if (!parsed.success) {
-    console.warn(`⚠ Unexpected Notion response shape: ${parsed.error.message}`);
-    return undefined;
-  }
-
-  return parsed.data;
+    },
+    {
+      schema: notionDatabaseQueryResponseSchema,
+      label: 'Notion API',
+      fetcher: retryFetch,
+    },
+  );
 }
 
 /**
@@ -193,22 +170,11 @@ export async function fetchPage(
   token: string,
   pageId: string,
 ): Promise<NotionPage | undefined> {
-  try {
-    const response = await retryFetch(`${NOTION_API}/pages/${pageId}`, {
-      headers: notionHeaders(token),
-    });
-
-    if (!response.ok) return undefined;
-
-    const json: unknown = await response.json();
-    const parsed = notionPageSchema.safeParse(json);
-
-    if (!parsed.success) return undefined;
-
-    return parsed.data;
-  } catch {
-    return undefined;
-  }
+  return await fetchAndParse(
+    `${NOTION_API}/pages/${pageId}`,
+    { headers: notionHeaders(token) },
+    { schema: notionPageSchema, label: 'Notion page', fetcher: retryFetch },
+  );
 }
 
 /**

--- a/src/scripts/board/shortcut/shortcut.ts
+++ b/src/scripts/board/shortcut/shortcut.ts
@@ -20,6 +20,7 @@ import type {
   ShortcutStoryNode,
   ShortcutWorkflowsResponse,
 } from '~/schemas/shortcut.js';
+import { fetchAndParse } from '~/scripts/shared/http/fetch-and-parse.js';
 import type { Ticket } from '~/types/index.js';
 
 const SHORTCUT_API = 'https://api.app.shortcut.com/api/v3';
@@ -122,34 +123,14 @@ export async function fetchWorkflows(
 ): Promise<ShortcutWorkflowsResponse> {
   if (cachedWorkflows) return cachedWorkflows;
 
-  try {
-    const response = await fetch(`${SHORTCUT_API}/workflows`, {
-      headers: shortcutHeaders(token),
-    });
+  const data = await fetchAndParse(
+    `${SHORTCUT_API}/workflows`,
+    { headers: shortcutHeaders(token) },
+    { schema: shortcutWorkflowsResponseSchema, label: 'Shortcut workflows' },
+  );
 
-    if (!response.ok) {
-      console.warn(`⚠ Shortcut /workflows returned HTTP ${response.status}`);
-      return [];
-    }
-
-    const json: unknown = await response.json();
-    const parsed = shortcutWorkflowsResponseSchema.safeParse(json);
-
-    if (!parsed.success) {
-      console.warn(
-        `⚠ Unexpected Shortcut workflows response: ${parsed.error.message}`,
-      );
-      return [];
-    }
-
-    cachedWorkflows = parsed.data;
-    return cachedWorkflows;
-  } catch (err) {
-    console.warn(
-      `⚠ Shortcut /workflows request failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return [];
-  }
+  if (data) cachedWorkflows = data;
+  return data ?? [];
 }
 
 /**
@@ -332,33 +313,25 @@ export async function fetchStory(
   token: string,
   storyId: number,
 ): Promise<ShortcutTicket | undefined> {
-  try {
-    const response = await fetch(`${SHORTCUT_API}/stories/${storyId}`, {
-      headers: shortcutHeaders(token),
-    });
+  const story = await fetchAndParse(
+    `${SHORTCUT_API}/stories/${storyId}`,
+    { headers: shortcutHeaders(token) },
+    { schema: shortcutStoryDetailResponseSchema, label: 'Shortcut story' },
+  );
 
-    if (!response.ok) return undefined;
+  if (!story) return undefined;
 
-    const json: unknown = await response.json();
-    const parsed = shortcutStoryDetailResponseSchema.safeParse(json);
-
-    if (!parsed.success) return undefined;
-
-    const story = parsed.data;
-    return {
-      key: `sc-${story.id}`,
-      title: story.name,
-      description: story.description ?? '',
-      provider: 'shortcut' as const,
-      storyId: story.id,
-      epicId: story.epic_id ?? undefined,
-      labels: story.labels
-        ?.map((l) => l.name)
-        .filter((n): n is string => Boolean(n)),
-    };
-  } catch {
-    return undefined;
-  }
+  return {
+    key: `sc-${story.id}`,
+    title: story.name,
+    description: story.description ?? '',
+    provider: 'shortcut' as const,
+    storyId: story.id,
+    epicId: story.epic_id ?? undefined,
+    labels: story.labels
+      ?.map((l) => l.name)
+      .filter((n): n is string => Boolean(n)),
+  };
 }
 
 /**
@@ -616,34 +589,14 @@ export async function fetchLabels(
 ): Promise<ShortcutLabelsResponse> {
   if (cachedLabels) return cachedLabels;
 
-  try {
-    const response = await fetch(`${SHORTCUT_API}/labels`, {
-      headers: shortcutHeaders(token),
-    });
+  const data = await fetchAndParse(
+    `${SHORTCUT_API}/labels`,
+    { headers: shortcutHeaders(token) },
+    { schema: shortcutLabelsResponseSchema, label: 'Shortcut labels' },
+  );
 
-    if (!response.ok) {
-      console.warn(`⚠ Shortcut /labels returned HTTP ${response.status}`);
-      return [];
-    }
-
-    const json: unknown = await response.json();
-    const parsed = shortcutLabelsResponseSchema.safeParse(json);
-
-    if (!parsed.success) {
-      console.warn(
-        `⚠ Unexpected Shortcut labels response: ${parsed.error.message}`,
-      );
-      return [];
-    }
-
-    cachedLabels = parsed.data;
-    return cachedLabels;
-  } catch (err) {
-    console.warn(
-      `⚠ Shortcut /labels request failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return [];
-  }
+  if (data) cachedLabels = data;
+  return data ?? [];
 }
 
 /**
@@ -657,33 +610,23 @@ export async function createLabel(
   token: string,
   name: string,
 ): Promise<number | undefined> {
-  try {
-    const response = await fetch(`${SHORTCUT_API}/labels`, {
+  const data = await fetchAndParse(
+    `${SHORTCUT_API}/labels`,
+    {
       method: 'POST',
       headers: shortcutHeaders(token),
       body: JSON.stringify({ name, color: '#0075ca' }),
-    });
+    },
+    {
+      schema: shortcutLabelCreateResponseSchema,
+      label: 'Shortcut label create',
+    },
+  );
 
-    if (!response.ok) {
-      console.warn(`⚠ Shortcut label create returned HTTP ${response.status}`);
-      return undefined;
-    }
+  // Invalidate label cache so next fetchLabels picks up the new label
+  if (data) cachedLabels = undefined;
 
-    const json: unknown = await response.json();
-    const parsed = shortcutLabelCreateResponseSchema.safeParse(json);
-
-    if (!parsed.success) return undefined;
-
-    // Invalidate label cache so next fetchLabels picks up the new label
-    cachedLabels = undefined;
-
-    return parsed.data.id;
-  } catch (err) {
-    console.warn(
-      `⚠ Shortcut label create failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return undefined;
-  }
+  return data?.id;
 }
 
 /**
@@ -697,22 +640,13 @@ export async function getStoryLabelIds(
   token: string,
   storyId: number,
 ): Promise<number[] | undefined> {
-  try {
-    const response = await fetch(`${SHORTCUT_API}/stories/${storyId}`, {
-      headers: shortcutHeaders(token),
-    });
+  const data = await fetchAndParse(
+    `${SHORTCUT_API}/stories/${storyId}`,
+    { headers: shortcutHeaders(token) },
+    { schema: shortcutStoryDetailResponseSchema, label: 'Shortcut story' },
+  );
 
-    if (!response.ok) return undefined;
-
-    const json: unknown = await response.json();
-    const parsed = shortcutStoryDetailResponseSchema.safeParse(json);
-
-    if (!parsed.success) return undefined;
-
-    return parsed.data.label_ids ?? [];
-  } catch {
-    return undefined;
-  }
+  return data ? (data.label_ids ?? []) : undefined;
 }
 
 /**

--- a/src/scripts/shared/http/fetch-and-parse.test.ts
+++ b/src/scripts/shared/http/fetch-and-parse.test.ts
@@ -222,7 +222,11 @@ describe('fetchAndParse', () => {
   });
 
   it('does not call global fetch when custom fetcher is provided', async () => {
-    const globalFetch = vi.spyOn(globalThis, 'fetch');
+    const globalFetch = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      throw new Error(
+        'global fetch should not be called when custom fetcher is provided',
+      );
+    });
     const customFetcher = vi
       .fn<typeof fetch>()
       .mockResolvedValue(

--- a/src/scripts/shared/http/fetch-and-parse.test.ts
+++ b/src/scripts/shared/http/fetch-and-parse.test.ts
@@ -200,4 +200,58 @@ describe('fetchAndParse', () => {
     expect(result).toBeUndefined();
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('string error'));
   });
+
+  it('uses custom fetcher when provided', async () => {
+    const customFetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ id: 1, name: 'Custom' }), {
+        status: 200,
+      }),
+    );
+
+    const result = await fetchAndParse(
+      'https://api.example.com/custom',
+      { method: 'POST' },
+      { schema: testSchema, label, fetcher: customFetcher },
+    );
+
+    expect(result).toEqual({ id: 1, name: 'Custom' });
+    expect(customFetcher).toHaveBeenCalledWith(
+      'https://api.example.com/custom',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('does not call global fetch when custom fetcher is provided', async () => {
+    const globalFetch = vi.spyOn(globalThis, 'fetch');
+    const customFetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ id: 1, name: 'Test' }), { status: 200 }),
+      );
+
+    await fetchAndParse('https://api.example.com', undefined, {
+      schema: testSchema,
+      label,
+      fetcher: customFetcher,
+    });
+
+    expect(globalFetch).not.toHaveBeenCalled();
+    expect(customFetcher).toHaveBeenCalled();
+  });
+
+  it('handles custom fetcher errors the same as global fetch', async () => {
+    const customFetcher = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(new Error('rate limited'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await fetchAndParse('https://api.example.com', undefined, {
+      schema: testSchema,
+      label,
+      fetcher: customFetcher,
+    });
+
+    expect(result).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('rate limited'));
+  });
 });

--- a/src/scripts/shared/http/fetch-and-parse.ts
+++ b/src/scripts/shared/http/fetch-and-parse.ts
@@ -17,6 +17,8 @@ export type FetchAndParseOptions<T> = {
   schema: ZodMiniType<T>;
   /** Human-readable label for error messages (e.g., `'Jira API'`). */
   label: string;
+  /** Custom fetch function (e.g., `retryFetch` for Notion rate limits). Defaults to global `fetch`. */
+  fetcher?: (url: string, init?: RequestInit) => Promise<Response>;
 };
 
 /**
@@ -36,11 +38,11 @@ export async function fetchAndParse<T>(
   init: RequestInit | undefined,
   opts: FetchAndParseOptions<T>,
 ): Promise<T | undefined> {
-  const { schema, label } = opts;
+  const { schema, label, fetcher = fetch } = opts;
 
   let response: Response;
   try {
-    response = await fetch(url, init);
+    response = await fetcher(url, init);
   } catch (err) {
     console.warn(
       `⚠ ${label} request failed: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
## Summary

- **fetchAndParse custom fetcher** — optional `fetcher` param for boards needing custom fetch functions (e.g., Notion's `retryFetch` for rate limits). 3 new unit tests.
- **Linear board** — converted 5 functions (`fetchIssues`, `fetchBlockerStatus`, `lookupWorkflowStateId`, `executeStateTransition`, `fetchChildrenByDescription`). Added `linearInit()` helper for GraphQL requests. Reused `linearInit()` in `linearGraphql()` and `pingLinear()` to prevent divergence.
- **Shortcut board** — converted 5 functions (`fetchWorkflows`, `fetchLabels`, `createLabel`, `fetchStory`, `getStoryLabelIds`).
- **Notion board** — converted 2 functions (`queryDatabase`, `fetchPage`) using `fetcher: retryFetch`.
- **Azure DevOps board** — converted 3 functions (`runWiql`, `fetchWorkItem`, `fetchChildrenByLinks`).

Net -69 lines of boilerplate across 7 files. Only functions fitting the single-request + JSON + Zod pattern were converted. Board-specific wrappers (pagination, multi-step, fallback logic) remain unchanged.

## Test plan

- [x] All 1261 unit tests pass (`npm test`)
- [x] All 238 integration tests pass (`npm run test:integration`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] DA review — 0 critical, 0 medium (after fixes)
- [x] Copilot review — 2 comments addressed (hermetic test spy + `linearInit` reuse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)