### PR TITLE
♻️ refactor: deliverViaPullRequest — options object + computeDeliveryOutcome (PR 2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Headers: `✨ Features`, `🐛 Fixes`, `♻️ Refactors`, `✅ Tests`, `📝 Do
 - **Shortcut board: use `fetchAndParse`** — converted `fetchWorkflows()`, `fetchLabels()`, `createLabel()`, `fetchStory()`, `getStoryLabelIds()`. Removed ~75 lines of boilerplate.
 - **Notion board: use `fetchAndParse`** — converted `queryDatabase()` and `fetchPage()` using the custom `fetcher` param with `retryFetch`. Removed ~30 lines of boilerplate.
 - **Azure DevOps board: use `fetchAndParse`** — converted `runWiql()`, `fetchWorkItem()`, `fetchChildrenByLinks()`. Removed ~40 lines of boilerplate.
+- **`DeliveryParams` options object** — replaced 9 positional parameters on `deliverViaPullRequest()` with a single `DeliveryParams` type. Named properties make call sites self-documenting.
+- **`computeDeliveryOutcome()` pure function** — extracted PR outcome logic from the 103-line if/else chain in `deliverViaPullRequest()` into a testable pure function. Returns a `DeliveryOutcome` discriminated union (`created`, `exists`, `failed`, `no_token`, `local`, `unsupported`). Orchestrator switches on outcome type for logging and progress. 8 new unit tests.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Headers: `✨ Features`, `🐛 Fixes`, `♻️ Refactors`, `✅ Tests`, `📝 Do
 - **Notion board: use `fetchAndParse`** — converted `queryDatabase()` and `fetchPage()` using the custom `fetcher` param with `retryFetch`. Removed ~30 lines of boilerplate.
 - **Azure DevOps board: use `fetchAndParse`** — converted `runWiql()`, `fetchWorkItem()`, `fetchChildrenByLinks()`. Removed ~40 lines of boilerplate.
 - **`DeliveryParams` options object** — replaced 9 positional parameters on `deliverViaPullRequest()` with a single `DeliveryParams` type. Named properties make call sites self-documenting.
-- **`computeDeliveryOutcome()` pure function** — extracted PR outcome logic from the 103-line if/else chain in `deliverViaPullRequest()` into a testable pure function. Returns a `DeliveryOutcome` discriminated union (`created`, `exists`, `failed`, `no_token`, `local`, `unsupported`). Orchestrator switches on outcome type for logging and progress. 8 new unit tests.
+- **`computeDeliveryOutcome()` pure function** — extracted PR outcome logic from the 103-line if/else chain in `deliverViaPullRequest()` into a testable pure function. Returns a `DeliveryOutcome` discriminated union (`created`, `exists`, `failed`, `not_attempted`, `local`, `unsupported`). Orchestrator switches on outcome type for logging and progress. 8 new unit tests.
 
 ---
 

--- a/src/scripts/once/deliver/deliver.test.ts
+++ b/src/scripts/once/deliver/deliver.test.ts
@@ -168,13 +168,13 @@ describe('deliverViaPullRequest', () => {
 
   it('pushes branch and creates PR, logs PR_CREATED', async () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const result = await deliverViaPullRequest(
-      jiraConfig,
+    const result = await deliverViaPullRequest({
+      config: jiraConfig,
       ticket,
-      'feature/proj-1',
-      'main',
-      Date.now(),
-    );
+      ticketBranch: 'feature/proj-1',
+      targetBranch: 'main',
+      startTime: Date.now(),
+    });
     log.mockRestore();
 
     expect(result).toBe(true);
@@ -191,15 +191,14 @@ describe('deliverViaPullRequest', () => {
 
   it('passes parent key to appendProgress', async () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-    await deliverViaPullRequest(
-      jiraConfig,
+    await deliverViaPullRequest({
+      config: jiraConfig,
       ticket,
-      'feature/proj-1',
-      'epic/proj-100',
-      Date.now(),
-      false,
-      'PROJ-100',
-    );
+      ticketBranch: 'feature/proj-1',
+      targetBranch: 'epic/proj-100',
+      startTime: Date.now(),
+      parent: 'PROJ-100',
+    });
     log.mockRestore();
 
     expect(appendProgress).toHaveBeenCalledWith(
@@ -216,13 +215,13 @@ describe('deliverViaPullRequest', () => {
     vi.mocked(pushBranch).mockReturnValue(false);
 
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const result = await deliverViaPullRequest(
-      jiraConfig,
+    const result = await deliverViaPullRequest({
+      config: jiraConfig,
       ticket,
-      'feature/proj-1',
-      'main',
-      Date.now(),
-    );
+      ticketBranch: 'feature/proj-1',
+      targetBranch: 'main',
+      startTime: Date.now(),
+    });
     log.mockRestore();
 
     expect(result).toBe(false);
@@ -238,14 +237,14 @@ describe('deliverViaPullRequest', () => {
 
   it('skips progress log when skipLog is true', async () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-    await deliverViaPullRequest(
-      jiraConfig,
+    await deliverViaPullRequest({
+      config: jiraConfig,
       ticket,
-      'feature/proj-1',
-      'main',
-      Date.now(),
-      true,
-    );
+      ticketBranch: 'feature/proj-1',
+      targetBranch: 'main',
+      startTime: Date.now(),
+      skipLog: true,
+    });
     log.mockRestore();
 
     expect(appendProgress).not.toHaveBeenCalled();
@@ -253,13 +252,13 @@ describe('deliverViaPullRequest', () => {
 
   it('checks out target branch after delivery', async () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-    await deliverViaPullRequest(
-      jiraConfig,
+    await deliverViaPullRequest({
+      config: jiraConfig,
       ticket,
-      'feature/proj-1',
-      'main',
-      Date.now(),
-    );
+      ticketBranch: 'feature/proj-1',
+      targetBranch: 'main',
+      startTime: Date.now(),
+    });
     log.mockRestore();
 
     expect(checkout).toHaveBeenCalledWith('main');
@@ -295,15 +294,14 @@ describe('deliverViaPullRequest', () => {
     });
 
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-    await deliverViaPullRequest(
-      jiraConfig,
+    await deliverViaPullRequest({
+      config: jiraConfig,
       ticket,
-      'feature/proj-1',
-      'epic/proj-100',
-      Date.now(),
-      false,
-      'PROJ-100',
-    );
+      ticketBranch: 'feature/proj-1',
+      targetBranch: 'epic/proj-100',
+      startTime: Date.now(),
+      parent: 'PROJ-100',
+    });
     log.mockRestore();
 
     expect(buildPrBody).toHaveBeenCalledWith(
@@ -323,15 +321,14 @@ describe('deliverViaPullRequest', () => {
   it('does not pass epicContext when targeting non-epic branch', async () => {
     vi.mocked(pushBranch).mockReturnValue(true);
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-    await deliverViaPullRequest(
-      jiraConfig,
+    await deliverViaPullRequest({
+      config: jiraConfig,
       ticket,
-      'feature/proj-1',
-      'main',
-      Date.now(),
-      false,
-      'PROJ-100',
-    );
+      ticketBranch: 'feature/proj-1',
+      targetBranch: 'main',
+      startTime: Date.now(),
+      parent: 'PROJ-100',
+    });
     log.mockRestore();
 
     expect(buildPrBody).toHaveBeenCalledWith(

--- a/src/scripts/once/deliver/deliver.ts
+++ b/src/scripts/once/deliver/deliver.ts
@@ -300,7 +300,7 @@ export async function deliverViaPullRequest(
         );
       break;
 
-    case 'no_token':
+    case 'not_attempted':
       if (outcome.manualUrl) {
         console.log(dim(`  Create a PR: ${outcome.manualUrl}`));
       } else {

--- a/src/scripts/once/deliver/deliver.ts
+++ b/src/scripts/once/deliver/deliver.ts
@@ -33,6 +33,22 @@ import {
   attemptPrCreation,
   buildManualPrUrl,
 } from '../pr-creation/pr-creation.js';
+import { computeDeliveryOutcome } from './outcome.js';
+
+// ─── Delivery parameter types ────────────────────────────────────────────────
+
+/** Parameters for {@link deliverViaPullRequest}. */
+export type DeliveryParams = {
+  config: BoardConfig;
+  ticket: FetchedTicket;
+  ticketBranch: string;
+  targetBranch: string;
+  startTime: number;
+  skipLog?: boolean;
+  parent?: string;
+  board?: Board;
+  singleChildParent?: string;
+};
 
 /**
  * Ensure the epic branch exists locally and on the remote.
@@ -120,20 +136,24 @@ export function ensureEpicBranch(
 /**
  * PR flow: push branch to remote, create PR/MR, transition to In Review.
  *
- * @param parent - Optional parent key for progress logging (epic branch flow).
  * @returns `false` if the push failed (caller should handle early return).
  */
 export async function deliverViaPullRequest(
-  config: BoardConfig,
-  ticket: FetchedTicket,
-  ticketBranch: string,
-  targetBranch: string,
-  startTime: number,
-  skipLog = false,
-  parent?: string,
-  board?: Board, // Required in practice — all phase callers pass ctx.board
-  singleChildParent?: string, // Parent key when single-child skip is active
+  params: DeliveryParams,
 ): Promise<boolean> {
+  const {
+    config,
+    ticket,
+    ticketBranch,
+    targetBranch,
+    startTime,
+    skipLog = false,
+    parent,
+    board,
+    singleChildParent,
+  } = params;
+
+  // ── Push ──────────────────────────────────────────────────────────────────
   const pushed = pushBranch(ticketBranch);
 
   if (!pushed) {
@@ -162,27 +182,24 @@ export async function deliverViaPullRequest(
 
   console.log(green(`  ✓ Pushed ${ticketBranch}`));
 
-  // Check for verification warnings (file exists when verification didn't fully pass)
+  // ── Verification warning ──────────────────────────────────────────────────
   let verificationWarning: string | undefined;
   try {
     const attemptPath = join(process.cwd(), '.clancy', 'verify-attempt.txt');
     const attempt = readFileSync(attemptPath, 'utf8').trim();
     const attemptNum = parseInt(attempt, 10);
     if (attemptNum > 0) {
-      // The file exists = verification didn't fully pass. The number is
-      // the attempt counter (1 = ran once and failed, 2 = ran twice, etc.)
       verificationWarning = `Verification checks did not fully pass (${attemptNum} attempt(s)). Review carefully.`;
     }
   } catch {
     // No verify-attempt file — verification passed or wasn't run
   }
 
-  // Attempt PR/MR creation
+  // ── PR body + epic context ────────────────────────────────────────────────
   const platformOverride = sharedEnv(config).CLANCY_GIT_PLATFORM;
   const remote = detectRemote(platformOverride);
   const prTitle = `feat(${ticket.key}): ${ticket.title}`;
 
-  // Build epic context for child PRs targeting epic/milestone branches
   let epicContext: EpicContext | undefined;
   if (parent && isEpicBranch(targetBranch)) {
     const siblingEntries = [...DELIVERED_STATUSES]
@@ -209,32 +226,46 @@ export async function deliverViaPullRequest(
     epicContext,
   );
 
-  if (
+  // ── PR creation + outcome ─────────────────────────────────────────────────
+  const canCreatePr =
     remote.host !== 'none' &&
     remote.host !== 'unknown' &&
-    remote.host !== 'azure'
-  ) {
-    const pr = await attemptPrCreation(
-      config,
-      remote,
-      ticketBranch,
-      targetBranch,
-      prTitle,
-      prBody,
-    );
+    remote.host !== 'azure';
 
-    if (pr?.ok) {
-      console.log(green(`  ✓ PR created: ${pr.url}`));
+  const pr = canCreatePr
+    ? await attemptPrCreation(
+        config,
+        remote,
+        ticketBranch,
+        targetBranch,
+        prTitle,
+        prBody,
+      )
+    : undefined;
+
+  const outcome = computeDeliveryOutcome(
+    pr,
+    remote,
+    ticketBranch,
+    targetBranch,
+  );
+
+  // ── Log + progress based on outcome ───────────────────────────────────────
+  switch (outcome.type) {
+    case 'created':
+      console.log(green(`  ✓ PR created: ${outcome.url}`));
       if (!skipLog)
         appendProgress(
           process.cwd(),
           ticket.key,
           ticket.title,
           'PR_CREATED',
-          pr.number,
+          outcome.number,
           parent,
         );
-    } else if (pr && !pr.ok && pr.alreadyExists) {
+      break;
+
+    case 'exists':
       console.log(
         yellow(
           `  ⚠ A PR/MR already exists for ${ticketBranch}. Branch pushed.`,
@@ -249,11 +280,12 @@ export async function deliverViaPullRequest(
           undefined,
           parent,
         );
-    } else if (pr && !pr.ok) {
-      console.log(yellow(`  ⚠ PR/MR creation failed: ${pr.error}`));
-      const manualUrl = buildManualPrUrl(remote, ticketBranch, targetBranch);
-      if (manualUrl) {
-        console.log(dim(`  Create one manually: ${manualUrl}`));
+      break;
+
+    case 'failed':
+      console.log(yellow(`  ⚠ PR/MR creation failed: ${outcome.error}`));
+      if (outcome.manualUrl) {
+        console.log(dim(`  Create one manually: ${outcome.manualUrl}`));
       } else {
         console.log(dim('  Branch pushed — create a PR/MR manually.'));
       }
@@ -266,11 +298,11 @@ export async function deliverViaPullRequest(
           undefined,
           parent,
         );
-    } else {
-      // No token available for this platform
-      const manualUrl = buildManualPrUrl(remote, ticketBranch, targetBranch);
-      if (manualUrl) {
-        console.log(dim(`  Create a PR: ${manualUrl}`));
+      break;
+
+    case 'no_token':
+      if (outcome.manualUrl) {
+        console.log(dim(`  Create a PR: ${outcome.manualUrl}`));
       } else {
         console.log(dim('  Branch pushed to remote. Create a PR/MR manually.'));
       }
@@ -283,38 +315,41 @@ export async function deliverViaPullRequest(
           undefined,
           parent,
         );
-    }
-  } else if (remote.host === 'none') {
-    console.log(
-      yellow(
-        `⚠ No git remote configured. Branch available locally: ${ticketBranch}`,
-      ),
-    );
-    if (!skipLog)
-      appendProgress(
-        process.cwd(),
-        ticket.key,
-        ticket.title,
-        'LOCAL',
-        undefined,
-        parent,
+      break;
+
+    case 'local':
+      console.log(
+        yellow(
+          `⚠ No git remote configured. Branch available locally: ${ticketBranch}`,
+        ),
       );
-  } else {
-    // Unknown or Azure remote — just note the push
-    console.log(dim('  Branch pushed to remote. Create a PR/MR manually.'));
-    if (!skipLog)
-      appendProgress(
-        process.cwd(),
-        ticket.key,
-        ticket.title,
-        'PUSHED',
-        undefined,
-        parent,
-      );
+      if (!skipLog)
+        appendProgress(
+          process.cwd(),
+          ticket.key,
+          ticket.title,
+          'LOCAL',
+          undefined,
+          parent,
+        );
+      break;
+
+    case 'unsupported':
+      console.log(dim('  Branch pushed to remote. Create a PR/MR manually.'));
+      if (!skipLog)
+        appendProgress(
+          process.cwd(),
+          ticket.key,
+          ticket.title,
+          'PUSHED',
+          undefined,
+          parent,
+        );
+      break;
   }
 
-  // Transition to In Review (not Done — PR hasn't been merged yet)
-  // For GitHub Issues: do NOT close — PR body has "Closes #N" (or "Part of") for auto-close on merge
+  // ── Board transition ──────────────────────────────────────────────────────
+  // For GitHub Issues: do NOT close — PR body has "Closes #N" for auto-close on merge
   if (config.provider !== 'github' && board) {
     const statusReview =
       config.env.CLANCY_STATUS_REVIEW ?? config.env.CLANCY_STATUS_DONE;
@@ -323,7 +358,6 @@ export async function deliverViaPullRequest(
     }
   }
 
-  // Switch back to target branch
   checkout(targetBranch);
   return true;
 }

--- a/src/scripts/once/deliver/outcome.test.ts
+++ b/src/scripts/once/deliver/outcome.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PrCreationResult, RemoteInfo } from '~/types/index.js';
+
+import { computeDeliveryOutcome } from './outcome.js';
+import type { DeliveryOutcome } from './outcome.js';
+
+const githubRemote: RemoteInfo = {
+  host: 'github',
+  owner: 'owner',
+  repo: 'repo',
+  hostname: 'github.com',
+};
+
+const gitlabRemote: RemoteInfo = {
+  host: 'gitlab',
+  hostname: 'gitlab.com',
+  projectPath: 'owner/repo',
+};
+
+describe('computeDeliveryOutcome', () => {
+  it('returns "created" when PR was successfully created', () => {
+    const pr: PrCreationResult = {
+      ok: true,
+      url: 'https://github.com/o/r/pull/42',
+      number: 42,
+    };
+
+    const result = computeDeliveryOutcome(
+      pr,
+      githubRemote,
+      'feature/x',
+      'main',
+    );
+
+    expect(result).toEqual<DeliveryOutcome>({
+      type: 'created',
+      url: 'https://github.com/o/r/pull/42',
+      number: 42,
+    });
+  });
+
+  it('returns "exists" when PR already exists', () => {
+    const pr: PrCreationResult = {
+      ok: false,
+      error: 'already exists',
+      alreadyExists: true,
+    };
+
+    const result = computeDeliveryOutcome(
+      pr,
+      githubRemote,
+      'feature/x',
+      'main',
+    );
+
+    expect(result).toEqual<DeliveryOutcome>({ type: 'exists' });
+  });
+
+  it('returns "failed" with error and manual URL when PR creation fails', () => {
+    const pr: PrCreationResult = {
+      ok: false,
+      error: 'Validation Failed',
+    };
+
+    const result = computeDeliveryOutcome(
+      pr,
+      githubRemote,
+      'feature/x',
+      'main',
+    );
+
+    expect(result.type).toBe('failed');
+    if (result.type === 'failed') {
+      expect(result.error).toBe('Validation Failed');
+      expect(result.manualUrl).toBeDefined();
+    }
+  });
+
+  it('returns "no_token" with manual URL when pr is undefined', () => {
+    const result = computeDeliveryOutcome(
+      undefined,
+      githubRemote,
+      'feature/x',
+      'main',
+    );
+
+    expect(result.type).toBe('no_token');
+    if (result.type === 'no_token') {
+      expect(result.manualUrl).toBeDefined();
+    }
+  });
+
+  it('returns "local" when remote host is "none"', () => {
+    const noneRemote: RemoteInfo = { host: 'none' } as RemoteInfo;
+
+    const result = computeDeliveryOutcome(
+      undefined,
+      noneRemote,
+      'feature/x',
+      'main',
+    );
+
+    expect(result).toEqual<DeliveryOutcome>({ type: 'local' });
+  });
+
+  it('returns "unsupported" when remote host is "unknown"', () => {
+    const unknownRemote: RemoteInfo = { host: 'unknown' } as RemoteInfo;
+
+    const result = computeDeliveryOutcome(
+      undefined,
+      unknownRemote,
+      'feature/x',
+      'main',
+    );
+
+    expect(result).toEqual<DeliveryOutcome>({ type: 'unsupported' });
+  });
+
+  it('returns "unsupported" when remote host is "azure"', () => {
+    const azureRemote: RemoteInfo = { host: 'azure' } as RemoteInfo;
+
+    const result = computeDeliveryOutcome(
+      undefined,
+      azureRemote,
+      'feature/x',
+      'main',
+    );
+
+    expect(result).toEqual<DeliveryOutcome>({ type: 'unsupported' });
+  });
+
+  it('includes manual URL for GitLab remotes', () => {
+    const pr: PrCreationResult = {
+      ok: false,
+      error: 'forbidden',
+    };
+
+    const result = computeDeliveryOutcome(
+      pr,
+      gitlabRemote,
+      'feature/x',
+      'main',
+    );
+
+    expect(result.type).toBe('failed');
+    if (result.type === 'failed') {
+      expect(result.manualUrl).toBeDefined();
+    }
+  });
+});

--- a/src/scripts/once/deliver/outcome.test.ts
+++ b/src/scripts/once/deliver/outcome.test.ts
@@ -77,7 +77,7 @@ describe('computeDeliveryOutcome', () => {
     }
   });
 
-  it('returns "no_token" with manual URL when pr is undefined', () => {
+  it('returns "not_attempted" with manual URL when pr is undefined', () => {
     const result = computeDeliveryOutcome(
       undefined,
       githubRemote,
@@ -85,14 +85,14 @@ describe('computeDeliveryOutcome', () => {
       'main',
     );
 
-    expect(result.type).toBe('no_token');
-    if (result.type === 'no_token') {
+    expect(result.type).toBe('not_attempted');
+    if (result.type === 'not_attempted') {
       expect(result.manualUrl).toBeDefined();
     }
   });
 
   it('returns "local" when remote host is "none"', () => {
-    const noneRemote: RemoteInfo = { host: 'none' } as RemoteInfo;
+    const noneRemote: RemoteInfo = { host: 'none' };
 
     const result = computeDeliveryOutcome(
       undefined,
@@ -105,7 +105,10 @@ describe('computeDeliveryOutcome', () => {
   });
 
   it('returns "unsupported" when remote host is "unknown"', () => {
-    const unknownRemote: RemoteInfo = { host: 'unknown' } as RemoteInfo;
+    const unknownRemote: RemoteInfo = {
+      host: 'unknown',
+      url: 'https://example.invalid',
+    };
 
     const result = computeDeliveryOutcome(
       undefined,
@@ -118,7 +121,10 @@ describe('computeDeliveryOutcome', () => {
   });
 
   it('returns "unsupported" when remote host is "azure"', () => {
-    const azureRemote: RemoteInfo = { host: 'azure' } as RemoteInfo;
+    const azureRemote: RemoteInfo = {
+      host: 'azure',
+      url: 'https://dev.azure.com/org/project/_git/repo',
+    };
 
     const result = computeDeliveryOutcome(
       undefined,

--- a/src/scripts/once/deliver/outcome.ts
+++ b/src/scripts/once/deliver/outcome.ts
@@ -64,7 +64,7 @@ export function computeDeliveryOutcome(
     };
   }
 
-  // No token available — couldn't attempt PR creation
+  // PR creation not attempted (e.g., missing token or API base URL)
   return {
     type: 'not_attempted',
     manualUrl: buildManualPrUrl(remote, ticketBranch, targetBranch),

--- a/src/scripts/once/deliver/outcome.ts
+++ b/src/scripts/once/deliver/outcome.ts
@@ -14,7 +14,7 @@ export type DeliveryOutcome =
   | { type: 'created'; url: string; number: number }
   | { type: 'exists' }
   | { type: 'failed'; error: string; manualUrl?: string }
-  | { type: 'no_token'; manualUrl?: string }
+  | { type: 'not_attempted'; manualUrl?: string }
   | { type: 'local' }
   | { type: 'unsupported' };
 
@@ -24,7 +24,8 @@ export type DeliveryOutcome =
  * Pure function — no side effects, no I/O. The caller handles logging
  * and progress based on the returned outcome type.
  *
- * @param pr - The PR creation result, or `undefined` if no token was available.
+ * @param pr - The PR creation result, or `undefined` if PR creation was not attempted
+ *   (e.g., no token available, no API base URL, or unsupported platform).
  * @param remote - The detected remote info.
  * @param ticketBranch - The branch that was pushed (for manual URL construction).
  * @param targetBranch - The target branch (for manual URL construction).
@@ -65,7 +66,7 @@ export function computeDeliveryOutcome(
 
   // No token available — couldn't attempt PR creation
   return {
-    type: 'no_token',
+    type: 'not_attempted',
     manualUrl: buildManualPrUrl(remote, ticketBranch, targetBranch),
   };
 }

--- a/src/scripts/once/deliver/outcome.ts
+++ b/src/scripts/once/deliver/outcome.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure outcome computation for delivery results.
+ *
+ * Replaces the if/else chain in `deliverViaPullRequest` with a
+ * discriminated union. The orchestrator switches on `type` for
+ * logging and progress, keeping side effects separate from decisions.
+ */
+import type { PrCreationResult, RemoteInfo } from '~/types/index.js';
+
+import { buildManualPrUrl } from '../pr-creation/pr-creation.js';
+
+/** Discriminated union of all possible delivery outcomes after push succeeds. */
+export type DeliveryOutcome =
+  | { type: 'created'; url: string; number: number }
+  | { type: 'exists' }
+  | { type: 'failed'; error: string; manualUrl?: string }
+  | { type: 'no_token'; manualUrl?: string }
+  | { type: 'local' }
+  | { type: 'unsupported' };
+
+/**
+ * Compute the delivery outcome from a PR creation result and remote info.
+ *
+ * Pure function — no side effects, no I/O. The caller handles logging
+ * and progress based on the returned outcome type.
+ *
+ * @param pr - The PR creation result, or `undefined` if no token was available.
+ * @param remote - The detected remote info.
+ * @param ticketBranch - The branch that was pushed (for manual URL construction).
+ * @param targetBranch - The target branch (for manual URL construction).
+ * @returns The delivery outcome.
+ */
+export function computeDeliveryOutcome(
+  pr: PrCreationResult | undefined,
+  remote: RemoteInfo,
+  ticketBranch: string,
+  targetBranch: string,
+): DeliveryOutcome {
+  // No remote configured
+  if (remote.host === 'none') return { type: 'local' };
+
+  // Unsupported remote (unknown or Azure — no PR API)
+  if (remote.host === 'unknown' || remote.host === 'azure') {
+    return { type: 'unsupported' };
+  }
+
+  // PR was created successfully
+  if (pr?.ok) {
+    return { type: 'created', url: pr.url, number: pr.number };
+  }
+
+  // PR already exists
+  if (pr && !pr.ok && pr.alreadyExists) {
+    return { type: 'exists' };
+  }
+
+  // PR creation failed with an error
+  if (pr && !pr.ok) {
+    return {
+      type: 'failed',
+      error: pr.error,
+      manualUrl: buildManualPrUrl(remote, ticketBranch, targetBranch),
+    };
+  }
+
+  // No token available — couldn't attempt PR creation
+  return {
+    type: 'no_token',
+    manualUrl: buildManualPrUrl(remote, ticketBranch, targetBranch),
+  };
+}

--- a/src/scripts/once/phases/deliver.test.ts
+++ b/src/scripts/once/phases/deliver.test.ts
@@ -56,17 +56,12 @@ describe('deliver', () => {
     const result = await deliver(makeCtx());
 
     expect(result).toBe(true);
-    expect(mockDeliver).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      'feature/proj-1',
-      'main',
-      expect.any(Number),
-      false,
-      undefined,
-      undefined,
-      undefined, // singleChildParent
-    );
+    const call = mockDeliver.mock.calls[0][0];
+    expect(call.ticketBranch).toBe('feature/proj-1');
+    expect(call.targetBranch).toBe('main');
+    expect(call.skipLog).toBeUndefined();
+    expect(call.parent).toBeUndefined();
+    expect(call.singleChildParent).toBeUndefined();
   });
 
   it('returns false when fresh delivery fails', async () => {
@@ -90,14 +85,11 @@ describe('deliver', () => {
 
     expect(result).toBe(true);
     expect(mockDeliver).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      'feature/proj-1',
-      'main',
-      expect.any(Number),
-      true,
-      undefined,
-      undefined,
+      expect.objectContaining({
+        ticketBranch: 'feature/proj-1',
+        targetBranch: 'main',
+        skipLog: true,
+      }),
     );
     expect(mockAppendProgress).toHaveBeenCalledWith(
       expect.any(String),
@@ -134,15 +126,11 @@ describe('deliver', () => {
     await deliver(ctx);
 
     expect(mockDeliver).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      'feature/proj-1',
-      'main',
-      expect.any(Number),
-      false,
-      'EPIC-10',
-      undefined,
-      undefined, // singleChildParent (not active when epic branch is used)
+      expect.objectContaining({
+        ticketBranch: 'feature/proj-1',
+        targetBranch: 'main',
+        parent: 'EPIC-10',
+      }),
     );
   });
 

--- a/src/scripts/once/phases/deliver.ts
+++ b/src/scripts/once/phases/deliver.ts
@@ -38,16 +38,16 @@ export async function deliver(ctx: RunContext): Promise<boolean> {
 
   if (isRework) {
     // PR-flow rework: push to existing branch, PR updates automatically
-    const delivered = await deliverViaPullRequest(
+    const delivered = await deliverViaPullRequest({
       config,
       ticket,
       ticketBranch,
-      effectiveTarget,
-      ctx.startTime,
-      true,
-      parentKey,
-      ctx.board,
-    );
+      targetBranch: effectiveTarget,
+      startTime: ctx.startTime,
+      skipLog: true,
+      parent: parentKey,
+      board: ctx.board,
+    });
     if (!delivered) {
       appendProgress(
         ctx.cwd,
@@ -85,17 +85,16 @@ export async function deliver(ctx: RunContext): Promise<boolean> {
     }
   } else {
     // Fresh ticket: deliver via PR (to epic branch or base branch)
-    const delivered = await deliverViaPullRequest(
+    const delivered = await deliverViaPullRequest({
       config,
       ticket,
       ticketBranch,
-      effectiveTarget,
-      ctx.startTime,
-      false,
-      parentKey,
-      ctx.board,
+      targetBranch: effectiveTarget,
+      startTime: ctx.startTime,
+      parent: parentKey,
+      board: ctx.board,
       singleChildParent,
-    );
+    });
     if (!delivered) return false;
 
     // Quality tracking (best-effort)


### PR DESCRIPTION
## Summary

- **`DeliveryParams` options object** — replaced 9 positional parameters on `deliverViaPullRequest()` with a single typed object. Named properties make call sites self-documenting (no more `true, undefined, ctx.board` positional guessing).
- **`computeDeliveryOutcome()` pure function** — extracted the 103-line if/else chain into a testable pure function in `outcome.ts`. Returns a `DeliveryOutcome` discriminated union (`created`, `exists`, `failed`, `not_attempted`, `local`, `unsupported`). The orchestrator switches on outcome type for logging and progress — decisions separated from side effects.
- **Updated callers** — both call sites in `phases/deliver.ts` now use named properties.
- **Strengthened phase tests** — fresh delivery test explicitly asserts `skipLog`, `parent`, and `singleChildParent` are undefined (DA review finding M2).

## Test plan

- [x] All 1269 unit tests pass (`npm test`)
- [x] All 238 integration tests pass (`npm run test:integration`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] DA review — 0 critical, 0 medium (after M2 fix)
- [x] Copilot review — 4 comments addressed (type cast removal + `no_token` → `not_attempted` rename)
- [x] 8 new unit tests for `computeDeliveryOutcome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)