### PR TITLE
♻️ refactor: delivery orchestrator simplification (PR 2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Headers: `✨ Features`, `🐛 Fixes`, `♻️ Refactors`, `✅ Tests`, `📝 Do
 - **Azure DevOps board: use `fetchAndParse`** — converted `runWiql()`, `fetchWorkItem()`, `fetchChildrenByLinks()`. Removed ~40 lines of boilerplate.
 - **`DeliveryParams` options object** — replaced 9 positional parameters on `deliverViaPullRequest()` with a single `DeliveryParams` type. Named properties make call sites self-documenting.
 - **`computeDeliveryOutcome()` pure function** — extracted PR outcome logic from the 103-line if/else chain in `deliverViaPullRequest()` into a testable pure function. Returns a `DeliveryOutcome` discriminated union (`created`, `exists`, `failed`, `not_attempted`, `local`, `unsupported`). Orchestrator switches on outcome type for logging and progress. 8 new unit tests.
+- **Delivery orchestrator simplification** — extracted `readVerificationWarning()`, `buildEpicContext()`, `logOutcome()`, and `progressForOutcome()` helpers. Replaced 6 duplicated `appendProgress` calls in the switch with a single call using `progressForOutcome()`. Applied `computeDeliveryOutcome` to `deliverEpicToBase`. Removed unnecessary `else` in `ensureEpicBranch`. 6 new unit tests.
 
 ---
 

--- a/src/scripts/once/deliver/deliver.ts
+++ b/src/scripts/once/deliver/deliver.ts
@@ -459,5 +459,9 @@ export async function deliverEpicToBase(
     case 'local':
     case 'unsupported':
       return false;
+    default: {
+      const _exhaustive: never = outcome;
+      return _exhaustive;
+    }
   }
 }

--- a/src/scripts/once/deliver/deliver.ts
+++ b/src/scripts/once/deliver/deliver.ts
@@ -33,7 +33,8 @@ import {
   attemptPrCreation,
   buildManualPrUrl,
 } from '../pr-creation/pr-creation.js';
-import { computeDeliveryOutcome } from './outcome.js';
+import { computeDeliveryOutcome, progressForOutcome } from './outcome.js';
+import type { DeliveryOutcome } from './outcome.js';
 
 // ─── Delivery parameter types ────────────────────────────────────────────────
 
@@ -117,9 +118,8 @@ export function ensureEpicBranch(
         yellow(`⚠ Created ${epicBranch} locally but could not push to origin.`),
       );
       return false;
-    } else {
-      console.log(green(`  ✓ Created epic branch ${epicBranch}`));
     }
+    console.log(green(`  ✓ Created epic branch ${epicBranch}`));
     return true;
   } catch (err) {
     console.log(
@@ -128,6 +128,83 @@ export function ensureEpicBranch(
       ),
     );
     return false;
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Read the verification attempt counter (0 = passed or not run). */
+function readVerificationWarning(): string | undefined {
+  try {
+    const attemptPath = join(process.cwd(), '.clancy', 'verify-attempt.txt');
+    const attempt = readFileSync(attemptPath, 'utf8').trim();
+    const attemptNum = parseInt(attempt, 10);
+    if (attemptNum > 0) {
+      return `Verification checks did not fully pass (${attemptNum} attempt(s)). Review carefully.`;
+    }
+  } catch {
+    // No verify-attempt file — verification passed or wasn't run
+  }
+  return undefined;
+}
+
+/** Compute epic context for child PRs targeting epic/milestone branches. */
+function buildEpicContext(
+  parent: string | undefined,
+  targetBranch: string,
+  ticketKey: string,
+): EpicContext | undefined {
+  if (!parent || !isEpicBranch(targetBranch)) return undefined;
+
+  const siblingEntries = [...DELIVERED_STATUSES]
+    .flatMap((s) => findEntriesWithStatus(process.cwd(), s))
+    .filter((e) => e.parent === parent && e.key !== ticketKey);
+
+  return {
+    parentKey: parent,
+    siblingsDelivered: siblingEntries.length,
+    epicBranch: targetBranch,
+  };
+}
+
+/** Log console output for a delivery outcome. */
+function logOutcome(outcome: DeliveryOutcome, ticketBranch: string): void {
+  switch (outcome.type) {
+    case 'created':
+      console.log(green(`  ✓ PR created: ${outcome.url}`));
+      break;
+    case 'exists':
+      console.log(
+        yellow(
+          `  ⚠ A PR/MR already exists for ${ticketBranch}. Branch pushed.`,
+        ),
+      );
+      break;
+    case 'failed':
+      console.log(yellow(`  ⚠ PR/MR creation failed: ${outcome.error}`));
+      if (outcome.manualUrl) {
+        console.log(dim(`  Create one manually: ${outcome.manualUrl}`));
+      } else {
+        console.log(dim('  Branch pushed — create a PR/MR manually.'));
+      }
+      break;
+    case 'not_attempted':
+      if (outcome.manualUrl) {
+        console.log(dim(`  Create a PR: ${outcome.manualUrl}`));
+      } else {
+        console.log(dim('  Branch pushed to remote. Create a PR/MR manually.'));
+      }
+      break;
+    case 'local':
+      console.log(
+        yellow(
+          `⚠ No git remote configured. Branch available locally: ${ticketBranch}`,
+        ),
+      );
+      break;
+    case 'unsupported':
+      console.log(dim('  Branch pushed to remote. Create a PR/MR manually.'));
+      break;
   }
 }
 
@@ -182,35 +259,10 @@ export async function deliverViaPullRequest(
 
   console.log(green(`  ✓ Pushed ${ticketBranch}`));
 
-  // ── Verification warning ──────────────────────────────────────────────────
-  let verificationWarning: string | undefined;
-  try {
-    const attemptPath = join(process.cwd(), '.clancy', 'verify-attempt.txt');
-    const attempt = readFileSync(attemptPath, 'utf8').trim();
-    const attemptNum = parseInt(attempt, 10);
-    if (attemptNum > 0) {
-      verificationWarning = `Verification checks did not fully pass (${attemptNum} attempt(s)). Review carefully.`;
-    }
-  } catch {
-    // No verify-attempt file — verification passed or wasn't run
-  }
-
-  // ── PR body + epic context ────────────────────────────────────────────────
+  // ── PR creation + outcome ─────────────────────────────────────────────────
   const platformOverride = sharedEnv(config).CLANCY_GIT_PLATFORM;
   const remote = detectRemote(platformOverride);
   const prTitle = `feat(${ticket.key}): ${ticket.title}`;
-
-  let epicContext: EpicContext | undefined;
-  if (parent && isEpicBranch(targetBranch)) {
-    const siblingEntries = [...DELIVERED_STATUSES]
-      .flatMap((s) => findEntriesWithStatus(process.cwd(), s))
-      .filter((e) => e.parent === parent && e.key !== ticket.key);
-    epicContext = {
-      parentKey: parent,
-      siblingsDelivered: siblingEntries.length,
-      epicBranch: targetBranch,
-    };
-  }
 
   const prBody = buildPrBody(
     config,
@@ -221,12 +273,11 @@ export async function deliverViaPullRequest(
       provider: config.provider,
     },
     targetBranch,
-    verificationWarning,
+    readVerificationWarning(),
     singleChildParent,
-    epicContext,
+    buildEpicContext(parent, targetBranch, ticket.key),
   );
 
-  // ── PR creation + outcome ─────────────────────────────────────────────────
   const canCreatePr =
     remote.host !== 'none' &&
     remote.host !== 'unknown' &&
@@ -250,102 +301,19 @@ export async function deliverViaPullRequest(
     targetBranch,
   );
 
-  // ── Log + progress based on outcome ───────────────────────────────────────
-  switch (outcome.type) {
-    case 'created':
-      console.log(green(`  ✓ PR created: ${outcome.url}`));
-      if (!skipLog)
-        appendProgress(
-          process.cwd(),
-          ticket.key,
-          ticket.title,
-          'PR_CREATED',
-          outcome.number,
-          parent,
-        );
-      break;
+  // ── Log + progress ────────────────────────────────────────────────────────
+  logOutcome(outcome, ticketBranch);
 
-    case 'exists':
-      console.log(
-        yellow(
-          `  ⚠ A PR/MR already exists for ${ticketBranch}. Branch pushed.`,
-        ),
-      );
-      if (!skipLog)
-        appendProgress(
-          process.cwd(),
-          ticket.key,
-          ticket.title,
-          'PUSHED',
-          undefined,
-          parent,
-        );
-      break;
-
-    case 'failed':
-      console.log(yellow(`  ⚠ PR/MR creation failed: ${outcome.error}`));
-      if (outcome.manualUrl) {
-        console.log(dim(`  Create one manually: ${outcome.manualUrl}`));
-      } else {
-        console.log(dim('  Branch pushed — create a PR/MR manually.'));
-      }
-      if (!skipLog)
-        appendProgress(
-          process.cwd(),
-          ticket.key,
-          ticket.title,
-          'PUSHED',
-          undefined,
-          parent,
-        );
-      break;
-
-    case 'not_attempted':
-      if (outcome.manualUrl) {
-        console.log(dim(`  Create a PR: ${outcome.manualUrl}`));
-      } else {
-        console.log(dim('  Branch pushed to remote. Create a PR/MR manually.'));
-      }
-      if (!skipLog)
-        appendProgress(
-          process.cwd(),
-          ticket.key,
-          ticket.title,
-          'PUSHED',
-          undefined,
-          parent,
-        );
-      break;
-
-    case 'local':
-      console.log(
-        yellow(
-          `⚠ No git remote configured. Branch available locally: ${ticketBranch}`,
-        ),
-      );
-      if (!skipLog)
-        appendProgress(
-          process.cwd(),
-          ticket.key,
-          ticket.title,
-          'LOCAL',
-          undefined,
-          parent,
-        );
-      break;
-
-    case 'unsupported':
-      console.log(dim('  Branch pushed to remote. Create a PR/MR manually.'));
-      if (!skipLog)
-        appendProgress(
-          process.cwd(),
-          ticket.key,
-          ticket.title,
-          'PUSHED',
-          undefined,
-          parent,
-        );
-      break;
+  if (!skipLog) {
+    const { status, prNumber } = progressForOutcome(outcome);
+    appendProgress(
+      process.cwd(),
+      ticket.key,
+      ticket.title,
+      status,
+      prNumber,
+      parent,
+    );
   }
 
   // ── Board transition ──────────────────────────────────────────────────────
@@ -412,11 +380,12 @@ export async function deliverEpicToBase(
     config.provider,
   );
 
-  if (
-    remote.host === 'none' ||
-    remote.host === 'unknown' ||
-    remote.host === 'azure'
-  ) {
+  const canCreatePr =
+    remote.host !== 'none' &&
+    remote.host !== 'unknown' &&
+    remote.host !== 'azure';
+
+  if (!canCreatePr) {
     console.log(
       yellow(`⚠ Cannot create epic PR — no supported git remote detected.`),
     );
@@ -434,61 +403,66 @@ export async function deliverEpicToBase(
     prBody,
   );
 
-  if (pr?.ok) {
-    console.log(green(`  ✓ Epic PR created: ${pr.url}`));
-    appendProgress(
-      process.cwd(),
-      epicKey,
-      epicTitle,
-      'EPIC_PR_CREATED',
-      pr.number,
-    );
+  const outcome = computeDeliveryOutcome(pr, remote, epicBranch, baseBranch);
 
-    // Transition epic ticket to Review / add build label
-    if (config.provider === 'github' && board) {
-      // GitHub: add build label so downstream tooling (e.g., Ralph) can find the epic PR
-      const buildLabel = resolveBuildLabel(config.env);
-      if (buildLabel) {
-        await board.addLabel(epicKey, buildLabel);
-        console.log(
-          dim(`  Requested ${buildLabel} on ${epicKey} (best-effort)`),
-        );
+  switch (outcome.type) {
+    case 'created':
+      console.log(green(`  ✓ Epic PR created: ${outcome.url}`));
+      appendProgress(
+        process.cwd(),
+        epicKey,
+        epicTitle,
+        'EPIC_PR_CREATED',
+        outcome.number,
+      );
+
+      // Transition epic ticket to Review / add build label
+      if (config.provider === 'github' && board) {
+        const buildLabel = resolveBuildLabel(config.env);
+        if (buildLabel) {
+          await board.addLabel(epicKey, buildLabel);
+          console.log(
+            dim(`  Requested ${buildLabel} on ${epicKey} (best-effort)`),
+          );
+        }
+      } else if (board) {
+        const statusReview =
+          config.env.CLANCY_STATUS_REVIEW ?? config.env.CLANCY_STATUS_DONE;
+        if (statusReview) {
+          await board.transitionTicket(
+            {
+              key: epicKey,
+              title: epicTitle,
+              description: '',
+              parentInfo: 'none',
+              blockers: 'None',
+            },
+            statusReview,
+          );
+        }
       }
-    } else if (board) {
-      const statusReview =
-        config.env.CLANCY_STATUS_REVIEW ?? config.env.CLANCY_STATUS_DONE;
-      if (statusReview) {
-        await board.transitionTicket(
-          {
-            key: epicKey,
-            title: epicTitle,
-            description: '',
-            parentInfo: 'none',
-            blockers: 'None',
-          },
-          statusReview,
-        );
-      }
+
+      return true;
+
+    case 'exists':
+      console.log(yellow(`  ⚠ An epic PR already exists for ${epicBranch}.`));
+      appendProgress(process.cwd(), epicKey, epicTitle, 'EPIC_PR_CREATED');
+      return true;
+
+    case 'failed':
+    case 'not_attempted': {
+      const error = outcome.type === 'failed' ? outcome.error : 'unknown error';
+      console.log(yellow(`⚠ Epic PR creation failed: ${error}`));
+      console.log(dim(`  Create it manually:`));
+      console.log(dim(`    Branch: ${epicBranch} → ${baseBranch}`));
+      const manualUrl =
+        outcome.manualUrl ?? buildManualPrUrl(remote, epicBranch, baseBranch);
+      if (manualUrl) console.log(dim(`    ${manualUrl}`));
+      return false;
     }
 
-    return true;
+    // local/unsupported are unreachable — canCreatePr guard exits early
+    default:
+      return false;
   }
-
-  if (pr && !pr.ok && pr.alreadyExists) {
-    console.log(yellow(`  ⚠ An epic PR already exists for ${epicBranch}.`));
-    appendProgress(process.cwd(), epicKey, epicTitle, 'EPIC_PR_CREATED');
-    return true;
-  }
-
-  console.log(
-    yellow(`⚠ Epic PR creation failed: ${pr?.error ?? 'unknown error'}`),
-  );
-  console.log(dim(`  Create it manually:`));
-  console.log(dim(`    Branch: ${epicBranch} → ${baseBranch}`));
-  const manualUrl = buildManualPrUrl(remote, epicBranch, baseBranch);
-  if (manualUrl) {
-    console.log(dim(`    ${manualUrl}`));
-  }
-
-  return false;
 }

--- a/src/scripts/once/deliver/deliver.ts
+++ b/src/scripts/once/deliver/deliver.ts
@@ -29,10 +29,7 @@ import { DELIVERED_STATUSES } from '~/types/remote.js';
 import { dim, green, red, yellow } from '~/utils/ansi/ansi.js';
 
 import { resolveBuildLabel } from '../fetch-ticket/fetch-ticket.js';
-import {
-  attemptPrCreation,
-  buildManualPrUrl,
-} from '../pr-creation/pr-creation.js';
+import { attemptPrCreation } from '../pr-creation/pr-creation.js';
 import { computeDeliveryOutcome, progressForOutcome } from './outcome.js';
 import type { DeliveryOutcome } from './outcome.js';
 
@@ -455,14 +452,12 @@ export async function deliverEpicToBase(
       console.log(yellow(`⚠ Epic PR creation failed: ${error}`));
       console.log(dim(`  Create it manually:`));
       console.log(dim(`    Branch: ${epicBranch} → ${baseBranch}`));
-      const manualUrl =
-        outcome.manualUrl ?? buildManualPrUrl(remote, epicBranch, baseBranch);
-      if (manualUrl) console.log(dim(`    ${manualUrl}`));
+      if (outcome.manualUrl) console.log(dim(`    ${outcome.manualUrl}`));
       return false;
     }
 
-    // local/unsupported are unreachable — canCreatePr guard exits early
-    default:
+    case 'local':
+    case 'unsupported':
       return false;
   }
 }

--- a/src/scripts/once/deliver/outcome.test.ts
+++ b/src/scripts/once/deliver/outcome.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { PrCreationResult, RemoteInfo } from '~/types/index.js';
 
-import { computeDeliveryOutcome } from './outcome.js';
+import { computeDeliveryOutcome, progressForOutcome } from './outcome.js';
 import type { DeliveryOutcome } from './outcome.js';
 
 const githubRemote: RemoteInfo = {
@@ -154,4 +154,27 @@ describe('computeDeliveryOutcome', () => {
       expect(result.manualUrl).toBeDefined();
     }
   });
+});
+
+describe('progressForOutcome', () => {
+  it('maps "created" to PR_CREATED with PR number', () => {
+    expect(
+      progressForOutcome({ type: 'created', url: 'https://x', number: 42 }),
+    ).toEqual({ status: 'PR_CREATED', prNumber: 42 });
+  });
+
+  it('maps "local" to LOCAL', () => {
+    expect(progressForOutcome({ type: 'local' })).toEqual({ status: 'LOCAL' });
+  });
+
+  it.each(['exists', 'failed', 'not_attempted', 'unsupported'] as const)(
+    'maps "%s" to PUSHED',
+    (type) => {
+      const outcome =
+        type === 'failed' ? { type, error: 'err' as const } : { type };
+      expect(progressForOutcome(outcome as DeliveryOutcome)).toEqual({
+        status: 'PUSHED',
+      });
+    },
+  );
 });

--- a/src/scripts/once/deliver/outcome.ts
+++ b/src/scripts/once/deliver/outcome.ts
@@ -94,5 +94,9 @@ export function progressForOutcome(outcome: DeliveryOutcome): {
     case 'not_attempted':
     case 'unsupported':
       return { status: 'PUSHED' };
+    default: {
+      const _exhaustive: never = outcome;
+      return _exhaustive;
+    }
   }
 }

--- a/src/scripts/once/deliver/outcome.ts
+++ b/src/scripts/once/deliver/outcome.ts
@@ -5,7 +5,11 @@
  * discriminated union. The orchestrator switches on `type` for
  * logging and progress, keeping side effects separate from decisions.
  */
-import type { PrCreationResult, RemoteInfo } from '~/types/index.js';
+import type {
+  PrCreationResult,
+  ProgressStatus,
+  RemoteInfo,
+} from '~/types/index.js';
 
 import { buildManualPrUrl } from '../pr-creation/pr-creation.js';
 
@@ -69,4 +73,26 @@ export function computeDeliveryOutcome(
     type: 'not_attempted',
     manualUrl: buildManualPrUrl(remote, ticketBranch, targetBranch),
   };
+}
+
+/**
+ * Map a delivery outcome to the progress status and optional PR number.
+ *
+ * Pure function — used by the orchestrator to log progress after delivery.
+ */
+export function progressForOutcome(outcome: DeliveryOutcome): {
+  status: ProgressStatus;
+  prNumber?: number;
+} {
+  switch (outcome.type) {
+    case 'created':
+      return { status: 'PR_CREATED', prNumber: outcome.number };
+    case 'local':
+      return { status: 'LOCAL' };
+    case 'exists':
+    case 'failed':
+    case 'not_attempted':
+    case 'unsupported':
+      return { status: 'PUSHED' };
+  }
 }


### PR DESCRIPTION
## Summary

- **`logOutcome()` helper** — extracted switch-based console logging from `deliverViaPullRequest` into a reusable helper. Each of the 6 `DeliveryOutcome` types maps to specific console output.
- **`progressForOutcome()` pure function** — maps `DeliveryOutcome` to `ProgressStatus` + optional PR number. Replaced 6 duplicated `appendProgress` calls with a single call. Uses explicit case listing (no default) for compile-time exhaustive checking.
- **`readVerificationWarning()` + `buildEpicContext()` helpers** — extracted verification file read and epic sibling counting into focused helper functions.
- **`deliverEpicToBase` uses `computeDeliveryOutcome`** — replaced its if/else chain with the same outcome pattern. Explicit case listing (`created`, `exists`, `failed`/`not_attempted`) with unreachable default for `local`/`unsupported`.
- **`ensureEpicBranch` guard clause** — removed unnecessary `else` after early return.

## Test plan

- [x] All 1275 unit tests pass (`npm test`)
- [x] All 238 integration tests pass (`npm run test:integration`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] DA review — 0 critical, 2 medium fixed (exhaustive type checks)
- [x] 6 new unit tests for `progressForOutcome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)