### PR TITLE
♻️ refactor: board label CRUD consolidation (PR 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Headers: `✨ Features`, `🐛 Fixes`, `♻️ Refactors`, `✅ Tests`, `📝 Do
 - **`DeliveryParams` options object** — replaced 9 positional parameters on `deliverViaPullRequest()` with a single `DeliveryParams` type. Named properties make call sites self-documenting.
 - **`computeDeliveryOutcome()` pure function** — extracted PR outcome logic from the 103-line if/else chain in `deliverViaPullRequest()` into a testable pure function. Returns a `DeliveryOutcome` discriminated union (`created`, `exists`, `failed`, `not_attempted`, `local`, `unsupported`). Orchestrator switches on outcome type for logging and progress. 8 new unit tests.
 - **Delivery orchestrator simplification** — extracted `readVerificationWarning()`, `buildEpicContext()`, `logOutcome()`, and `progressForOutcome()` helpers. Replaced 6 duplicated `appendProgress` calls in the switch with a single call using `progressForOutcome()`. Applied `computeDeliveryOutcome` to `deliverEpicToBase`. Removed unnecessary `else` in `ensureEpicBranch`. 6 new unit tests.
+- **Board label CRUD consolidation** — shared `modifyLabelList<T>()` (generic read-modify-write with idempotence) and `safeLabel()` (try-catch + warn wrapper) in `src/scripts/board/label-helpers/`. Applied to Jira, Shortcut, Notion, Azure DevOps. Works with both string labels and numeric IDs. 10 new unit tests.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Headers: `✨ Features`, `🐛 Fixes`, `♻️ Refactors`, `✅ Tests`, `📝 Do
 - **`DeliveryParams` options object** — replaced 9 positional parameters on `deliverViaPullRequest()` with a single `DeliveryParams` type. Named properties make call sites self-documenting.
 - **`computeDeliveryOutcome()` pure function** — extracted PR outcome logic from the 103-line if/else chain in `deliverViaPullRequest()` into a testable pure function. Returns a `DeliveryOutcome` discriminated union (`created`, `exists`, `failed`, `not_attempted`, `local`, `unsupported`). Orchestrator switches on outcome type for logging and progress. 8 new unit tests.
 - **Delivery orchestrator simplification** — extracted `readVerificationWarning()`, `buildEpicContext()`, `logOutcome()`, and `progressForOutcome()` helpers. Replaced 6 duplicated `appendProgress` calls in the switch with a single call using `progressForOutcome()`. Applied `computeDeliveryOutcome` to `deliverEpicToBase`. Removed unnecessary `else` in `ensureEpicBranch`. 6 new unit tests.
-- **Board label CRUD consolidation** — shared `modifyLabelList<T>()` (generic read-modify-write with idempotence) and `safeLabel()` (try-catch + warn wrapper) in `src/scripts/board/label-helpers/`. Applied to Jira, Shortcut, Notion, Azure DevOps. Works with both string labels and numeric IDs. 10 new unit tests.
+- **Board label CRUD consolidation** — shared `modifyLabelList<T>()` (generic read-modify-write with idempotence) and `safeLabel()` (try-catch + warn wrapper) in `src/scripts/board/label-helpers/`. Applied to Jira, Shortcut, Notion, Azure DevOps. Works with both string labels and numeric IDs. 13 new unit tests.
 
 ---
 

--- a/src/scripts/board/azdo/azdo-board.ts
+++ b/src/scripts/board/azdo/azdo-board.ts
@@ -8,6 +8,7 @@ import type { AzdoEnv } from '~/schemas/env.js';
 import type { FetchedTicket } from '~/types/board.js';
 
 import type { Board, FetchTicketOpts } from '../board.js';
+import { modifyLabelList, safeLabel } from '../label-helpers/label-helpers.js';
 import {
   buildTagsString,
   fetchBlockerStatus as fetchAzdoBlockerStatus,
@@ -128,57 +129,51 @@ export function createAzdoBoard(env: AzdoEnv): Board {
     },
 
     async addLabel(issueKey: string, label: string) {
-      try {
+      await safeLabel(async () => {
         const workItemId = parseWorkItemId(issueKey);
         if (workItemId === undefined) return;
-
-        const item = await fetchWorkItem(org, project, pat, workItemId);
-        if (!item) return;
-
-        const currentTags = parseTags(item.fields['System.Tags']);
-        if (currentTags.includes(label)) return;
-
-        const newTags = [...currentTags, label];
-
-        await updateWorkItem(org, project, pat, workItemId, [
-          {
-            op: 'replace',
-            path: '/fields/System.Tags',
-            value: buildTagsString(newTags),
+        await modifyLabelList(
+          async () => {
+            const item = await fetchWorkItem(org, project, pat, workItemId);
+            return item ? parseTags(item.fields['System.Tags']) : undefined;
           },
-        ]);
-      } catch (err) {
-        console.warn(
-          `⚠ addLabel failed: ${err instanceof Error ? err.message : String(err)}`,
+          async (tags) => {
+            await updateWorkItem(org, project, pat, workItemId, [
+              {
+                op: 'replace',
+                path: '/fields/System.Tags',
+                value: buildTagsString(tags),
+              },
+            ]);
+          },
+          label,
+          'add',
         );
-      }
+      }, 'addLabel');
     },
 
     async removeLabel(issueKey: string, label: string) {
-      try {
+      await safeLabel(async () => {
         const workItemId = parseWorkItemId(issueKey);
         if (workItemId === undefined) return;
-
-        const item = await fetchWorkItem(org, project, pat, workItemId);
-        if (!item) return;
-
-        const currentTags = parseTags(item.fields['System.Tags']);
-        if (!currentTags.includes(label)) return;
-
-        const newTags = currentTags.filter((t) => t !== label);
-
-        await updateWorkItem(org, project, pat, workItemId, [
-          {
-            op: 'replace',
-            path: '/fields/System.Tags',
-            value: buildTagsString(newTags),
+        await modifyLabelList(
+          async () => {
+            const item = await fetchWorkItem(org, project, pat, workItemId);
+            return item ? parseTags(item.fields['System.Tags']) : undefined;
           },
-        ]);
-      } catch (err) {
-        console.warn(
-          `⚠ removeLabel failed: ${err instanceof Error ? err.message : String(err)}`,
+          async (tags) => {
+            await updateWorkItem(org, project, pat, workItemId, [
+              {
+                op: 'replace',
+                path: '/fields/System.Tags',
+                value: buildTagsString(tags),
+              },
+            ]);
+          },
+          label,
+          'remove',
         );
-      }
+      }, 'removeLabel');
     },
 
     sharedEnv() {

--- a/src/scripts/board/jira/jira-board.ts
+++ b/src/scripts/board/jira/jira-board.ts
@@ -9,6 +9,7 @@ import { jiraIssueLabelsResponseSchema } from '~/schemas/jira.js';
 import type { FetchedTicket } from '~/types/board.js';
 
 import type { Board, FetchTicketOpts } from '../board.js';
+import { modifyLabelList, safeLabel } from '../label-helpers/label-helpers.js';
 import {
   buildAuthHeader,
   fetchBlockerStatus as fetchJiraBlockerStatus,
@@ -27,6 +28,38 @@ import {
  */
 export function createJiraBoard(env: JiraEnv): Board {
   const auth = buildAuthHeader(env.JIRA_USER, env.JIRA_API_TOKEN);
+
+  async function fetchJiraLabels(
+    issueKey: string,
+  ): Promise<string[] | undefined> {
+    const res = await fetch(
+      `${env.JIRA_BASE_URL}/rest/api/3/issue/${encodeURIComponent(issueKey)}?fields=labels`,
+      { headers: { Authorization: auth, Accept: 'application/json' } },
+    );
+    if (!res.ok) {
+      console.warn(`⚠ label GET failed: HTTP ${res.status}`);
+      return undefined;
+    }
+    const json = jiraIssueLabelsResponseSchema.parse(await res.json());
+    return json.fields?.labels ?? [];
+  }
+
+  async function writeJiraLabels(
+    issueKey: string,
+    labels: string[],
+  ): Promise<void> {
+    const putRes = await fetch(
+      `${env.JIRA_BASE_URL}/rest/api/3/issue/${encodeURIComponent(issueKey)}`,
+      {
+        method: 'PUT',
+        headers: { Authorization: auth, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fields: { labels } }),
+      },
+    );
+    if (!putRes.ok) {
+      console.warn(`⚠ label PUT returned HTTP ${putRes.status}`);
+    }
+  }
 
   return {
     async ping() {
@@ -108,87 +141,27 @@ export function createJiraBoard(env: JiraEnv): Board {
     },
 
     async addLabel(issueKey: string, label: string) {
-      try {
+      await safeLabel(async () => {
         if (!/^[A-Z][A-Z0-9]+-\d+$/.test(issueKey)) return;
-
-        const res = await fetch(
-          `${env.JIRA_BASE_URL}/rest/api/3/issue/${encodeURIComponent(issueKey)}?fields=labels`,
-          { headers: { Authorization: auth, Accept: 'application/json' } },
+        await modifyLabelList(
+          () => fetchJiraLabels(issueKey),
+          (labels) => writeJiraLabels(issueKey, labels),
+          label,
+          'add',
         );
-
-        if (!res.ok) {
-          console.warn(`⚠ addLabel GET failed: HTTP ${res.status}`);
-          return;
-        }
-
-        const json = jiraIssueLabelsResponseSchema.parse(await res.json());
-        const current = json.fields?.labels ?? [];
-
-        if (current.includes(label)) return;
-
-        const putRes = await fetch(
-          `${env.JIRA_BASE_URL}/rest/api/3/issue/${encodeURIComponent(issueKey)}`,
-          {
-            method: 'PUT',
-            headers: {
-              Authorization: auth,
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-              fields: { labels: [...current, label] },
-            }),
-          },
-        );
-        if (!putRes.ok) {
-          console.warn(`⚠ addLabel PUT returned HTTP ${putRes.status}`);
-        }
-      } catch (err) {
-        console.warn(
-          `⚠ addLabel failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
+      }, 'addLabel');
     },
 
     async removeLabel(issueKey: string, label: string) {
-      try {
+      await safeLabel(async () => {
         if (!/^[A-Z][A-Z0-9]+-\d+$/.test(issueKey)) return;
-
-        const res = await fetch(
-          `${env.JIRA_BASE_URL}/rest/api/3/issue/${encodeURIComponent(issueKey)}?fields=labels`,
-          { headers: { Authorization: auth, Accept: 'application/json' } },
+        await modifyLabelList(
+          () => fetchJiraLabels(issueKey),
+          (labels) => writeJiraLabels(issueKey, labels),
+          label,
+          'remove',
         );
-
-        if (!res.ok) {
-          console.warn(`⚠ removeLabel GET failed: HTTP ${res.status}`);
-          return;
-        }
-
-        const json = jiraIssueLabelsResponseSchema.parse(await res.json());
-        const current = json.fields?.labels ?? [];
-
-        if (!current.includes(label)) return;
-
-        const putRes = await fetch(
-          `${env.JIRA_BASE_URL}/rest/api/3/issue/${encodeURIComponent(issueKey)}`,
-          {
-            method: 'PUT',
-            headers: {
-              Authorization: auth,
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-              fields: { labels: current.filter((l) => l !== label) },
-            }),
-          },
-        );
-        if (!putRes.ok) {
-          console.warn(`⚠ removeLabel PUT returned HTTP ${putRes.status}`);
-        }
-      } catch (err) {
-        console.warn(
-          `⚠ removeLabel failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
+      }, 'removeLabel');
     },
 
     sharedEnv() {

--- a/src/scripts/board/jira/jira-board.ts
+++ b/src/scripts/board/jira/jira-board.ts
@@ -37,7 +37,7 @@ export function createJiraBoard(env: JiraEnv): Board {
       { headers: { Authorization: auth, Accept: 'application/json' } },
     );
     if (!res.ok) {
-      console.warn(`⚠ label GET failed: HTTP ${res.status}`);
+      console.warn(`⚠ label GET ${issueKey} failed: HTTP ${res.status}`);
       return undefined;
     }
     const json = jiraIssueLabelsResponseSchema.parse(await res.json());
@@ -57,7 +57,7 @@ export function createJiraBoard(env: JiraEnv): Board {
       },
     );
     if (!putRes.ok) {
-      console.warn(`⚠ label PUT returned HTTP ${putRes.status}`);
+      console.warn(`⚠ label PUT ${issueKey} returned HTTP ${putRes.status}`);
     }
   }
 

--- a/src/scripts/board/label-helpers/label-helpers.test.ts
+++ b/src/scripts/board/label-helpers/label-helpers.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { modifyLabelList, safeLabel } from './label-helpers.js';
+
+describe('safeLabel', () => {
+  it('calls the operation and returns normally on success', async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    await safeLabel(fn, 'addLabel');
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it('catches errors and warns without throwing', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('network'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await safeLabel(fn, 'addLabel');
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('addLabel'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('network'));
+    warn.mockRestore();
+  });
+
+  it('handles non-Error throws', async () => {
+    const fn = vi.fn().mockRejectedValue('string error');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await safeLabel(fn, 'removeLabel');
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('string error'));
+    warn.mockRestore();
+  });
+});
+
+describe('modifyLabelList', () => {
+  it('adds a label when not present', async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+
+    await modifyLabelList(async () => ['a', 'b'], write, 'c', 'add');
+
+    expect(write).toHaveBeenCalledWith(['a', 'b', 'c']);
+  });
+
+  it('skips add when label already present', async () => {
+    const write = vi.fn();
+
+    await modifyLabelList(async () => ['a', 'b'], write, 'b', 'add');
+
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('removes a label when present', async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+
+    await modifyLabelList(async () => ['a', 'b', 'c'], write, 'b', 'remove');
+
+    expect(write).toHaveBeenCalledWith(['a', 'c']);
+  });
+
+  it('skips remove when label not present', async () => {
+    const write = vi.fn();
+
+    await modifyLabelList(async () => ['a', 'b'], write, 'z', 'remove');
+
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('returns early when fetchCurrent returns undefined', async () => {
+    const write = vi.fn();
+
+    await modifyLabelList(async () => undefined, write, 'x', 'add');
+
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('works with number arrays', async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+
+    await modifyLabelList(async () => [1, 2, 3], write, 4, 'add');
+
+    expect(write).toHaveBeenCalledWith([1, 2, 3, 4]);
+  });
+
+  it('removes from number arrays', async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+
+    await modifyLabelList(async () => [1, 2, 3], write, 2, 'remove');
+
+    expect(write).toHaveBeenCalledWith([1, 3]);
+  });
+
+  it('adds to empty array', async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+
+    await modifyLabelList(async () => [], write, 'first', 'add');
+
+    expect(write).toHaveBeenCalledWith(['first']);
+  });
+
+  it('skips remove from empty array', async () => {
+    const write = vi.fn();
+
+    await modifyLabelList(async () => [], write, 'x', 'remove');
+
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('propagates writeUpdated errors to caller', async () => {
+    const write = vi.fn().mockRejectedValue(new Error('write failed'));
+
+    await expect(
+      modifyLabelList(async () => ['a'], write, 'b', 'add'),
+    ).rejects.toThrow('write failed');
+  });
+});

--- a/src/scripts/board/label-helpers/label-helpers.ts
+++ b/src/scripts/board/label-helpers/label-helpers.ts
@@ -41,7 +41,7 @@ export async function safeLabel(
  * @param target - The label (or ID) to add or remove.
  * @param mode - Whether to add or remove the target.
  */
-export async function modifyLabelList<T>(
+export async function modifyLabelList<T extends string | number>(
   fetchCurrent: () => Promise<T[] | undefined>,
   writeUpdated: (updated: T[]) => Promise<void>,
   target: T,

--- a/src/scripts/board/label-helpers/label-helpers.ts
+++ b/src/scripts/board/label-helpers/label-helpers.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared label CRUD helpers for board wrappers.
+ *
+ * Boards with a read-modify-write pattern for labels (Jira, Shortcut,
+ * Notion, Azure DevOps) can use `modifyLabelList` to eliminate the
+ * duplicated fetch → check → write boilerplate. All label operations
+ * wrap in `safeLabel` for consistent error handling.
+ */
+
+/**
+ * Wrap a label operation in try-catch with a warning on failure.
+ *
+ * Label operations are best-effort — they should never crash the run.
+ *
+ * @param fn - The async label operation to execute.
+ * @param operation - Human-readable name for error messages (e.g., `'addLabel'`).
+ */
+export async function safeLabel(
+  fn: () => Promise<void>,
+  operation: string,
+): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    console.warn(
+      `⚠ ${operation} failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+/**
+ * Read-modify-write a label list with idempotence checking.
+ *
+ * Fetches the current labels, checks if the target is already present
+ * (add) or absent (remove), and writes the updated list only when a
+ * change is needed. Works with string labels (Jira, Notion, AzDO)
+ * and numeric IDs (Shortcut).
+ *
+ * @param fetchCurrent - Board-specific function to fetch current labels.
+ * @param writeUpdated - Board-specific function to write the updated list.
+ * @param target - The label (or ID) to add or remove.
+ * @param mode - Whether to add or remove the target.
+ */
+export async function modifyLabelList<T>(
+  fetchCurrent: () => Promise<T[] | undefined>,
+  writeUpdated: (updated: T[]) => Promise<void>,
+  target: T,
+  mode: 'add' | 'remove',
+): Promise<void> {
+  const current = await fetchCurrent();
+  if (!current) return;
+
+  const has = current.includes(target);
+  if (mode === 'add' && has) return;
+  if (mode === 'remove' && !has) return;
+
+  const updated =
+    mode === 'add'
+      ? [...current, target]
+      : current.filter((item) => item !== target);
+  await writeUpdated(updated);
+}

--- a/src/scripts/board/notion/notion-board.ts
+++ b/src/scripts/board/notion/notion-board.ts
@@ -13,6 +13,7 @@ import type { NotionPage } from '~/schemas/notion.js';
 import type { FetchedTicket } from '~/types/board.js';
 
 import type { Board, FetchTicketOpts } from '../board.js';
+import { modifyLabelList, safeLabel } from '../label-helpers/label-helpers.js';
 import {
   fetchBlockerStatus as fetchNotionBlockerStatus,
   fetchChildrenStatus as fetchNotionChildrenStatus,
@@ -155,55 +156,49 @@ export function createNotionBoard(env: NotionEnv): Board {
     },
 
     async addLabel(issueKey: string, label: string) {
-      try {
+      await safeLabel(async () => {
         const page = await resolvePageFromKey(
           env.NOTION_TOKEN,
           env.NOTION_DATABASE_ID,
           issueKey,
         );
         if (!page) return;
-
-        const currentLabels =
-          getPropertyValue(page, labelsProp, 'multi_select') ?? [];
-        if (currentLabels.includes(label)) return;
-
-        const newLabels = [...currentLabels, label].map((name) => ({ name }));
-
-        await updatePage(env.NOTION_TOKEN, page.id, {
-          [labelsProp]: { multi_select: newLabels },
-        });
-      } catch (err) {
-        console.warn(
-          `⚠ addLabel failed: ${err instanceof Error ? err.message : String(err)}`,
+        await modifyLabelList(
+          async () => getPropertyValue(page, labelsProp, 'multi_select') ?? [],
+          async (labels) => {
+            await updatePage(env.NOTION_TOKEN, page.id, {
+              [labelsProp]: {
+                multi_select: labels.map((name) => ({ name })),
+              },
+            });
+          },
+          label,
+          'add',
         );
-      }
+      }, 'addLabel');
     },
 
     async removeLabel(issueKey: string, label: string) {
-      try {
+      await safeLabel(async () => {
         const page = await resolvePageFromKey(
           env.NOTION_TOKEN,
           env.NOTION_DATABASE_ID,
           issueKey,
         );
         if (!page) return;
-
-        const currentLabels =
-          getPropertyValue(page, labelsProp, 'multi_select') ?? [];
-        if (!currentLabels.includes(label)) return;
-
-        const newLabels = currentLabels
-          .filter((name) => name !== label)
-          .map((name) => ({ name }));
-
-        await updatePage(env.NOTION_TOKEN, page.id, {
-          [labelsProp]: { multi_select: newLabels },
-        });
-      } catch (err) {
-        console.warn(
-          `⚠ removeLabel failed: ${err instanceof Error ? err.message : String(err)}`,
+        await modifyLabelList(
+          async () => getPropertyValue(page, labelsProp, 'multi_select') ?? [],
+          async (labels) => {
+            await updatePage(env.NOTION_TOKEN, page.id, {
+              [labelsProp]: {
+                multi_select: labels.map((name) => ({ name })),
+              },
+            });
+          },
+          label,
+          'remove',
         );
-      }
+      }, 'removeLabel');
     },
 
     sharedEnv() {

--- a/src/scripts/board/shortcut/shortcut-board.ts
+++ b/src/scripts/board/shortcut/shortcut-board.ts
@@ -8,6 +8,7 @@ import type { ShortcutEnv } from '~/schemas/env.js';
 import type { FetchedTicket } from '~/types/board.js';
 
 import type { Board, FetchTicketOpts } from '../board.js';
+import { modifyLabelList, safeLabel } from '../label-helpers/label-helpers.js';
 import {
   createLabel,
   fetchLabels,
@@ -120,21 +121,16 @@ export function createShortcutBoard(env: ShortcutEnv): Board {
     },
 
     async ensureLabel(label: string) {
-      try {
+      await safeLabel(async () => {
         const labels = await fetchLabels(env.SHORTCUT_API_TOKEN);
         const existing = labels.find((l) => l.name === label);
         if (existing) return;
-
         await createLabel(env.SHORTCUT_API_TOKEN, label);
-      } catch (err) {
-        console.warn(
-          `⚠ ensureLabel failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
+      }, 'ensureLabel');
     },
 
     async addLabel(issueKey: string, label: string) {
-      try {
+      await safeLabel(async () => {
         await this.ensureLabel(label);
 
         const storyId = parseStoryId(issueKey);
@@ -144,26 +140,19 @@ export function createShortcutBoard(env: ShortcutEnv): Board {
         const target = labels.find((l) => l.name === label);
         if (!target) return;
 
-        const currentIds = await getStoryLabelIds(
-          env.SHORTCUT_API_TOKEN,
-          storyId,
-        );
-        if (!currentIds) return;
-        if (currentIds.includes(target.id)) return;
-
-        await updateStoryLabelIds(env.SHORTCUT_API_TOKEN, storyId, [
-          ...currentIds,
+        await modifyLabelList(
+          () => getStoryLabelIds(env.SHORTCUT_API_TOKEN, storyId),
+          async (ids) => {
+            await updateStoryLabelIds(env.SHORTCUT_API_TOKEN, storyId, ids);
+          },
           target.id,
-        ]);
-      } catch (err) {
-        console.warn(
-          `⚠ addLabel failed: ${err instanceof Error ? err.message : String(err)}`,
+          'add',
         );
-      }
+      }, 'addLabel');
     },
 
     async removeLabel(issueKey: string, label: string) {
-      try {
+      await safeLabel(async () => {
         const storyId = parseStoryId(issueKey);
         if (storyId === undefined) return;
 
@@ -171,23 +160,15 @@ export function createShortcutBoard(env: ShortcutEnv): Board {
         const target = labels.find((l) => l.name === label);
         if (!target) return;
 
-        const currentIds = await getStoryLabelIds(
-          env.SHORTCUT_API_TOKEN,
-          storyId,
+        await modifyLabelList(
+          () => getStoryLabelIds(env.SHORTCUT_API_TOKEN, storyId),
+          async (ids) => {
+            await updateStoryLabelIds(env.SHORTCUT_API_TOKEN, storyId, ids);
+          },
+          target.id,
+          'remove',
         );
-        if (!currentIds) return;
-        if (!currentIds.includes(target.id)) return;
-
-        await updateStoryLabelIds(
-          env.SHORTCUT_API_TOKEN,
-          storyId,
-          currentIds.filter((id) => id !== target.id),
-        );
-      } catch (err) {
-        console.warn(
-          `⚠ removeLabel failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
+      }, 'removeLabel');
     },
 
     sharedEnv() {


### PR DESCRIPTION
## Summary

- **`modifyLabelList<T>()` shared helper** — generic read-modify-write with idempotence check. Fetches current labels, skips if already present (add) or absent (remove), writes updated list. Works with string labels (Jira, Notion, AzDO) and numeric IDs (Shortcut).
- **`safeLabel()` wrapper** — try-catch + console.warn for best-effort label operations. Consistent error handling across all boards.
- **Jira** — extracted `fetchJiraLabels()` and `writeJiraLabels()` helpers, wired through `modifyLabelList`.
- **Shortcut** — converted `ensureLabel`, `addLabel`, `removeLabel` to use helpers. Uses `modifyLabelList<number>` for label IDs.
- **Notion** — converted with inline callbacks for `multi_select` property format.
- **Azure DevOps** — converted with inline callbacks for `System.Tags` JSON Patch format.
- **GitHub and Linear not converted** — different API patterns (POST/DELETE vs read-modify-write, label ID caching).

Net -55 lines across 5 board files. New helpers in `src/scripts/board/label-helpers/`.

## Test plan

- [x] All 1288 unit tests pass (`npm test`)
- [x] All 238 integration tests pass (`npm run test:integration`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] DA review — 0 critical, 0 regressions (3 medium are pre-existing design choices)
- [x] 13 new unit tests (safeLabel + modifyLabelList including empty array, write propagation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)