### PR TITLE
♻️ refactor: rework platform handler map (PR 4a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Headers: `✨ Features`, `🐛 Fixes`, `♻️ Refactors`, `✅ Tests`, `📝 Do
 - **`computeDeliveryOutcome()` pure function** — extracted PR outcome logic from the 103-line if/else chain in `deliverViaPullRequest()` into a testable pure function. Returns a `DeliveryOutcome` discriminated union (`created`, `exists`, `failed`, `not_attempted`, `local`, `unsupported`). Orchestrator switches on outcome type for logging and progress. 8 new unit tests.
 - **Delivery orchestrator simplification** — extracted `readVerificationWarning()`, `buildEpicContext()`, `logOutcome()`, and `progressForOutcome()` helpers. Replaced 6 duplicated `appendProgress` calls in the switch with a single call using `progressForOutcome()`. Applied `computeDeliveryOutcome` to `deliverEpicToBase`. Removed unnecessary `else` in `ensureEpicBranch`. 6 new unit tests.
 - **Board label CRUD consolidation** — shared `modifyLabelList<T>()` (generic read-modify-write with idempotence) and `safeLabel()` (try-catch + warn wrapper) in `src/scripts/board/label-helpers/`. Applied to Jira, Shortcut, Notion, Azure DevOps. Works with both string labels and numeric IDs. 13 new unit tests.
+- **Rework platform handler map** — replaced 3 switch statements in `rework.ts` with `PlatformReworkHandlers` type and `resolvePlatformHandlers()` factory in `rework-handlers.ts`. Single switch creates a handler object; main functions call uniform methods (`checkReviewState`, `fetchComments`, `postComment`, `resolveThreads`, `reRequestReview`). Platform-specific no-ops for GitLab-only and GitHub-only actions.
 
 ---
 

--- a/src/scripts/once/rework/rework-handlers.test.ts
+++ b/src/scripts/once/rework/rework-handlers.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { BoardConfig } from '~/scripts/shared/env-schema/env-schema.js';
+
+import { resolvePlatformHandlers } from './rework-handlers.js';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock('~/scripts/shared/remote/remote.js', () => ({
+  buildApiBaseUrl: vi.fn(() => 'https://api.example.com'),
+  detectRemote: vi.fn(() => ({
+    host: 'github',
+    owner: 'owner',
+    repo: 'repo',
+    hostname: 'github.com',
+  })),
+}));
+
+vi.mock('../git-token/git-token.js', () => ({
+  resolveGitToken: vi.fn(() => ({ token: 'tok', username: 'user' })),
+}));
+
+vi.mock('~/scripts/shared/pull-request/github/github.js', () => ({
+  checkPrReviewState: vi.fn(() => Promise.resolve(undefined)),
+  fetchPrReviewComments: vi.fn(() => Promise.resolve(['comment'])),
+  postPrComment: vi.fn(() => Promise.resolve(true)),
+  requestReview: vi.fn(() => Promise.resolve(true)),
+}));
+
+vi.mock('~/scripts/shared/pull-request/gitlab/gitlab.js', () => ({
+  checkMrReviewState: vi.fn(() => Promise.resolve(undefined)),
+  fetchMrReviewComments: vi.fn(() =>
+    Promise.resolve({ comments: ['gl-comment'], discussionIds: ['d1'] }),
+  ),
+  postMrNote: vi.fn(() => Promise.resolve(true)),
+  resolveDiscussions: vi.fn(() => Promise.resolve(2)),
+}));
+
+vi.mock('~/scripts/shared/pull-request/bitbucket/bitbucket.js', () => ({
+  checkPrReviewState: vi.fn(() => Promise.resolve(undefined)),
+  checkServerPrReviewState: vi.fn(() => Promise.resolve(undefined)),
+  fetchPrReviewComments: vi.fn(() => Promise.resolve(['bb-comment'])),
+  fetchServerPrReviewComments: vi.fn(() => Promise.resolve(['bbs-comment'])),
+  postCloudPrComment: vi.fn(() => Promise.resolve(true)),
+  postServerPrComment: vi.fn(() => Promise.resolve(true)),
+}));
+
+const { detectRemote } = await import('~/scripts/shared/remote/remote.js');
+
+const config: BoardConfig = {
+  provider: 'github',
+  env: { GITHUB_TOKEN: 'ghp_test', GITHUB_REPO: 'owner/repo' },
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('resolvePlatformHandlers', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns undefined for unsupported hosts', () => {
+    vi.mocked(detectRemote).mockReturnValue({ host: 'none' });
+    expect(resolvePlatformHandlers(config)).toBeUndefined();
+
+    vi.mocked(detectRemote).mockReturnValue({
+      host: 'unknown',
+      url: 'https://x',
+    });
+    expect(resolvePlatformHandlers(config)).toBeUndefined();
+
+    vi.mocked(detectRemote).mockReturnValue({
+      host: 'azure',
+      url: 'https://x',
+    });
+    expect(resolvePlatformHandlers(config)).toBeUndefined();
+  });
+
+  it('returns handlers for GitHub', () => {
+    vi.mocked(detectRemote).mockReturnValue({
+      host: 'github',
+      owner: 'o',
+      repo: 'r',
+      hostname: 'github.com',
+    });
+
+    const h = resolvePlatformHandlers(config);
+    expect(h).toBeDefined();
+    expect(h!.resolveThreads).toBeDefined();
+    expect(h!.reRequestReview).toBeDefined();
+  });
+
+  it('GitHub resolveThreads is a no-op returning 0', async () => {
+    vi.mocked(detectRemote).mockReturnValue({
+      host: 'github',
+      owner: 'o',
+      repo: 'r',
+      hostname: 'github.com',
+    });
+
+    const h = resolvePlatformHandlers(config)!;
+    expect(await h.resolveThreads(1, ['d1'])).toBe(0);
+  });
+
+  it('returns handlers for GitLab', () => {
+    vi.mocked(detectRemote).mockReturnValue({
+      host: 'gitlab',
+      projectPath: 'owner/repo',
+      hostname: 'gitlab.com',
+    });
+
+    const h = resolvePlatformHandlers(config);
+    expect(h).toBeDefined();
+  });
+
+  it('GitLab reRequestReview is a no-op returning false', async () => {
+    vi.mocked(detectRemote).mockReturnValue({
+      host: 'gitlab',
+      projectPath: 'owner/repo',
+      hostname: 'gitlab.com',
+    });
+
+    const h = resolvePlatformHandlers(config)!;
+    expect(await h.reRequestReview(1, ['alice'])).toBe(false);
+  });
+
+  it('GitLab resolveThreads calls resolveDiscussions', async () => {
+    vi.mocked(detectRemote).mockReturnValue({
+      host: 'gitlab',
+      projectPath: 'owner/repo',
+      hostname: 'gitlab.com',
+    });
+
+    const h = resolvePlatformHandlers(config)!;
+    const resolved = await h.resolveThreads(42, ['d1', 'd2']);
+    expect(resolved).toBe(2);
+  });
+
+  it('returns handlers for Bitbucket Cloud', () => {
+    vi.mocked(detectRemote).mockReturnValue({
+      host: 'bitbucket',
+      workspace: 'ws',
+      repoSlug: 'repo',
+      hostname: 'bitbucket.org',
+    });
+
+    const h = resolvePlatformHandlers(config);
+    expect(h).toBeDefined();
+  });
+
+  it('Bitbucket Cloud no-ops return correct defaults', async () => {
+    vi.mocked(detectRemote).mockReturnValue({
+      host: 'bitbucket',
+      workspace: 'ws',
+      repoSlug: 'repo',
+      hostname: 'bitbucket.org',
+    });
+
+    const h = resolvePlatformHandlers(config)!;
+    expect(await h.resolveThreads(1, ['d1'])).toBe(0);
+    expect(await h.reRequestReview(1, ['alice'])).toBe(false);
+  });
+
+  it('returns handlers for Bitbucket Server', () => {
+    vi.mocked(detectRemote).mockReturnValue({
+      host: 'bitbucket-server',
+      projectKey: 'PROJ',
+      repoSlug: 'repo',
+      hostname: 'bb.acme.com',
+    });
+
+    const h = resolvePlatformHandlers(config);
+    expect(h).toBeDefined();
+  });
+
+  it('GitLab fetchComments returns discussionIds', async () => {
+    vi.mocked(detectRemote).mockReturnValue({
+      host: 'gitlab',
+      projectPath: 'owner/repo',
+      hostname: 'gitlab.com',
+    });
+
+    const h = resolvePlatformHandlers(config)!;
+    const result = await h.fetchComments(1);
+    expect(result.comments).toEqual(['gl-comment']);
+    expect(result.discussionIds).toEqual(['d1']);
+  });
+
+  it('GitHub fetchComments wraps string[] in object without discussionIds', async () => {
+    vi.mocked(detectRemote).mockReturnValue({
+      host: 'github',
+      owner: 'o',
+      repo: 'r',
+      hostname: 'github.com',
+    });
+
+    const h = resolvePlatformHandlers(config)!;
+    const result = await h.fetchComments(1);
+    expect(result.comments).toEqual(['comment']);
+    expect(result.discussionIds).toBeUndefined();
+  });
+});

--- a/src/scripts/once/rework/rework-handlers.ts
+++ b/src/scripts/once/rework/rework-handlers.ts
@@ -1,0 +1,224 @@
+/**
+ * Platform-specific rework handlers.
+ *
+ * Replaces the dual/triple switch statements in rework.ts with a single
+ * factory function that resolves the platform once, returning a handler
+ * object with uniform method signatures. The main rework functions call
+ * `handlers.checkReviewState(...)` instead of switching on `remote.host`.
+ */
+import type { BoardConfig } from '~/scripts/shared/env-schema/env-schema.js';
+import { sharedEnv } from '~/scripts/shared/env-schema/env-schema.js';
+import {
+  checkPrReviewState as checkBitbucketPrReviewState,
+  checkServerPrReviewState as checkBitbucketServerPrReviewState,
+  fetchPrReviewComments as fetchBitbucketPrReviewComments,
+  fetchServerPrReviewComments as fetchBitbucketServerPrReviewComments,
+  postCloudPrComment,
+  postServerPrComment,
+} from '~/scripts/shared/pull-request/bitbucket/bitbucket.js';
+import {
+  checkPrReviewState as checkGitHubPrReviewState,
+  fetchPrReviewComments as fetchGitHubPrReviewComments,
+  postPrComment as postGitHubPrComment,
+  requestReview as requestGitHubReview,
+} from '~/scripts/shared/pull-request/github/github.js';
+import {
+  checkMrReviewState as checkGitLabMrReviewState,
+  fetchMrReviewComments as fetchGitLabMrReviewComments,
+  postMrNote,
+  resolveDiscussions,
+} from '~/scripts/shared/pull-request/gitlab/gitlab.js';
+import {
+  buildApiBaseUrl,
+  detectRemote,
+} from '~/scripts/shared/remote/remote.js';
+import type { PrReviewState } from '~/types/index.js';
+
+import { resolveGitToken } from '../git-token/git-token.js';
+
+/** Uniform interface for platform-specific rework operations. */
+export type PlatformReworkHandlers = {
+  checkReviewState(
+    branch: string,
+    since?: string,
+  ): Promise<PrReviewState | undefined>;
+
+  fetchComments(
+    prNumber: number,
+    since?: string,
+  ): Promise<{ comments: string[]; discussionIds?: string[] }>;
+
+  postComment(prNumber: number, comment: string): Promise<boolean>;
+
+  /** GitLab-only: resolve discussion threads. No-op on other platforms. */
+  resolveThreads(prNumber: number, discussionIds: string[]): Promise<number>;
+
+  /** GitHub-only: re-request review. No-op on other platforms. */
+  reRequestReview(prNumber: number, reviewers: string[]): Promise<boolean>;
+};
+
+/**
+ * Resolve platform handlers for the current remote.
+ *
+ * Returns `undefined` if the platform is unsupported (none, unknown, azure)
+ * or credentials/API base are missing.
+ */
+export function resolvePlatformHandlers(
+  config: BoardConfig,
+): PlatformReworkHandlers | undefined {
+  const platformOverride = sharedEnv(config).CLANCY_GIT_PLATFORM;
+  const remote = detectRemote(platformOverride);
+
+  if (
+    remote.host === 'none' ||
+    remote.host === 'unknown' ||
+    remote.host === 'azure'
+  ) {
+    return undefined;
+  }
+
+  const creds = resolveGitToken(config, remote);
+  if (!creds) return undefined;
+
+  const apiBase = buildApiBaseUrl(remote, sharedEnv(config).CLANCY_GIT_API_URL);
+  if (!apiBase) return undefined;
+
+  const noopResolve = async () => 0;
+  const noopReRequest = async () => false;
+
+  switch (remote.host) {
+    case 'github': {
+      const repo = `${remote.owner}/${remote.repo}`;
+      return {
+        checkReviewState: (branch, since) =>
+          checkGitHubPrReviewState(
+            creds.token,
+            repo,
+            branch,
+            remote.owner,
+            apiBase,
+            since,
+          ),
+        fetchComments: async (prNumber, since) => ({
+          comments: await fetchGitHubPrReviewComments(
+            creds.token,
+            repo,
+            prNumber,
+            apiBase,
+            since,
+          ),
+        }),
+        postComment: (prNumber, comment) =>
+          postGitHubPrComment(creds.token, repo, prNumber, comment, apiBase),
+        resolveThreads: noopResolve,
+        reRequestReview: (prNumber, reviewers) =>
+          requestGitHubReview(creds.token, repo, prNumber, reviewers, apiBase),
+      };
+    }
+
+    case 'gitlab':
+      return {
+        checkReviewState: (branch, since) =>
+          checkGitLabMrReviewState(
+            creds.token,
+            apiBase,
+            remote.projectPath,
+            branch,
+            since,
+          ),
+        fetchComments: (prNumber, since) =>
+          fetchGitLabMrReviewComments(
+            creds.token,
+            apiBase,
+            remote.projectPath,
+            prNumber,
+            since,
+          ),
+        postComment: (prNumber, comment) =>
+          postMrNote(
+            creds.token,
+            apiBase,
+            remote.projectPath,
+            prNumber,
+            comment,
+          ),
+        resolveThreads: (prNumber, discussionIds) =>
+          resolveDiscussions(
+            creds.token,
+            apiBase,
+            remote.projectPath,
+            prNumber,
+            discussionIds,
+          ),
+        reRequestReview: noopReRequest,
+      };
+
+    case 'bitbucket':
+      return {
+        checkReviewState: (branch, since) =>
+          checkBitbucketPrReviewState(
+            creds.username!,
+            creds.token,
+            remote.workspace,
+            remote.repoSlug,
+            branch,
+            since,
+          ),
+        fetchComments: async (prNumber, since) => ({
+          comments: await fetchBitbucketPrReviewComments(
+            creds.username!,
+            creds.token,
+            remote.workspace,
+            remote.repoSlug,
+            prNumber,
+            since,
+          ),
+        }),
+        postComment: (prNumber, comment) =>
+          postCloudPrComment(
+            creds.username!,
+            creds.token,
+            remote.workspace,
+            remote.repoSlug,
+            prNumber,
+            comment,
+          ),
+        resolveThreads: noopResolve,
+        reRequestReview: noopReRequest,
+      };
+
+    case 'bitbucket-server':
+      return {
+        checkReviewState: (branch, since) =>
+          checkBitbucketServerPrReviewState(
+            creds.token,
+            apiBase,
+            remote.projectKey,
+            remote.repoSlug,
+            branch,
+            since,
+          ),
+        fetchComments: async (prNumber, since) => ({
+          comments: await fetchBitbucketServerPrReviewComments(
+            creds.token,
+            apiBase,
+            remote.projectKey,
+            remote.repoSlug,
+            prNumber,
+            since,
+          ),
+        }),
+        postComment: (prNumber, comment) =>
+          postServerPrComment(
+            creds.token,
+            apiBase,
+            remote.projectKey,
+            remote.repoSlug,
+            prNumber,
+            comment,
+          ),
+        resolveThreads: noopResolve,
+        reRequestReview: noopReRequest,
+      };
+  }
+}

--- a/src/scripts/once/rework/rework.ts
+++ b/src/scripts/once/rework/rework.ts
@@ -1,35 +1,10 @@
 import { computeTicketBranch } from '~/scripts/shared/branch/branch.js';
 import type { BoardConfig } from '~/scripts/shared/env-schema/env-schema.js';
-import { sharedEnv } from '~/scripts/shared/env-schema/env-schema.js';
 import { findEntriesWithStatus } from '~/scripts/shared/progress/progress.js';
-import {
-  checkPrReviewState as checkBitbucketPrReviewState,
-  checkServerPrReviewState as checkBitbucketServerPrReviewState,
-  fetchPrReviewComments as fetchBitbucketPrReviewComments,
-  fetchServerPrReviewComments as fetchBitbucketServerPrReviewComments,
-  postCloudPrComment,
-  postServerPrComment,
-} from '~/scripts/shared/pull-request/bitbucket/bitbucket.js';
-import {
-  checkPrReviewState as checkGitHubPrReviewState,
-  fetchPrReviewComments as fetchGitHubPrReviewComments,
-  postPrComment as postGitHubPrComment,
-  requestReview as requestGitHubReview,
-} from '~/scripts/shared/pull-request/github/github.js';
-import {
-  checkMrReviewState as checkGitLabMrReviewState,
-  fetchMrReviewComments as fetchGitLabMrReviewComments,
-  postMrNote,
-  resolveDiscussions,
-} from '~/scripts/shared/pull-request/gitlab/gitlab.js';
-import {
-  buildApiBaseUrl,
-  detectRemote,
-} from '~/scripts/shared/remote/remote.js';
 import type { FetchedTicket } from '~/types/board.js';
 import { dim } from '~/utils/ansi/ansi.js';
 
-import { resolveGitToken } from '../git-token/git-token.js';
+import { resolvePlatformHandlers } from './rework-handlers.js';
 
 // ─── PR-based rework detection ────────────────────────────────────────────────
 
@@ -60,22 +35,8 @@ export async function fetchReworkFromPrReview(config: BoardConfig): Promise<
   const candidates = [...prCreated, ...reworked, ...pushed, ...pushFailed];
   if (candidates.length === 0) return undefined;
 
-  const platformOverride = sharedEnv(config).CLANCY_GIT_PLATFORM;
-  const remote = detectRemote(platformOverride);
-
-  if (
-    remote.host === 'none' ||
-    remote.host === 'unknown' ||
-    remote.host === 'azure'
-  ) {
-    return undefined;
-  }
-
-  const creds = resolveGitToken(config, remote);
-  if (!creds) return undefined;
-
-  const apiBase = buildApiBaseUrl(remote, sharedEnv(config).CLANCY_GIT_API_URL);
-  if (!apiBase) return undefined;
+  const handlers = resolvePlatformHandlers(config);
+  if (!handlers) return undefined;
 
   // Limit to first 5 candidates to avoid rate limits
   const toCheck = candidates.slice(0, 5);
@@ -86,114 +47,19 @@ export async function fetchReworkFromPrReview(config: BoardConfig): Promise<
     // Convert progress timestamp (YYYY-MM-DD HH:MM) to ISO 8601 for API filtering.
     // Only comments created AFTER this timestamp should trigger rework,
     // preventing stale inline comments from causing infinite rework loops.
-    // Parse UTC timestamp (YYYY-MM-DD HH:MM) to ISO 8601.
-    // Falls back to undefined if timestamp is invalid (skips filtering).
     let since: string | undefined;
     if (entry.timestamp) {
       const date = new Date(entry.timestamp.replace(' ', 'T') + 'Z');
       since = Number.isNaN(date.getTime()) ? undefined : date.toISOString();
     }
 
-    let reviewState:
-      | {
-          changesRequested: boolean;
-          prNumber: number;
-          prUrl: string;
-          reviewers?: string[];
-        }
-      | undefined;
-
-    switch (remote.host) {
-      case 'github':
-        reviewState = await checkGitHubPrReviewState(
-          creds.token,
-          `${remote.owner}/${remote.repo}`,
-          branch,
-          remote.owner,
-          apiBase,
-          since,
-        );
-        break;
-      case 'gitlab':
-        reviewState = await checkGitLabMrReviewState(
-          creds.token,
-          apiBase,
-          remote.projectPath,
-          branch,
-          since,
-        );
-        break;
-      case 'bitbucket':
-        reviewState = await checkBitbucketPrReviewState(
-          creds.username!,
-          creds.token,
-          remote.workspace,
-          remote.repoSlug,
-          branch,
-          since,
-        );
-        break;
-      case 'bitbucket-server':
-        reviewState = await checkBitbucketServerPrReviewState(
-          creds.token,
-          apiBase,
-          remote.projectKey,
-          remote.repoSlug,
-          branch,
-          since,
-        );
-        break;
-    }
+    const reviewState = await handlers.checkReviewState(branch, since);
 
     if (reviewState?.changesRequested) {
-      // Fetch review comments for the PR
-      let feedback: string[] = [];
-
-      let discussionIds: string[] | undefined;
-
-      switch (remote.host) {
-        case 'github':
-          feedback = await fetchGitHubPrReviewComments(
-            creds.token,
-            `${remote.owner}/${remote.repo}`,
-            reviewState.prNumber,
-            apiBase,
-            since,
-          );
-          break;
-        case 'gitlab': {
-          const mrResult = await fetchGitLabMrReviewComments(
-            creds.token,
-            apiBase,
-            remote.projectPath,
-            reviewState.prNumber,
-            since,
-          );
-          feedback = mrResult.comments;
-          discussionIds = mrResult.discussionIds;
-          break;
-        }
-        case 'bitbucket':
-          feedback = await fetchBitbucketPrReviewComments(
-            creds.username!,
-            creds.token,
-            remote.workspace,
-            remote.repoSlug,
-            reviewState.prNumber,
-            since,
-          );
-          break;
-        case 'bitbucket-server':
-          feedback = await fetchBitbucketServerPrReviewComments(
-            creds.token,
-            apiBase,
-            remote.projectKey,
-            remote.repoSlug,
-            reviewState.prNumber,
-            since,
-          );
-          break;
-      }
+      const { comments, discussionIds } = await handlers.fetchComments(
+        reviewState.prNumber,
+        since,
+      );
 
       const ticket: FetchedTicket = {
         key: entry.key,
@@ -205,7 +71,7 @@ export async function fetchReworkFromPrReview(config: BoardConfig): Promise<
 
       return {
         ticket,
-        feedback,
+        feedback: comments,
         prNumber: reviewState.prNumber,
         discussionIds,
         reviewers: reviewState.reviewers ?? [],
@@ -248,70 +114,14 @@ export async function postReworkActions(
   discussionIds?: string[],
   reviewers?: string[],
 ): Promise<void> {
-  const platformOverride = sharedEnv(config).CLANCY_GIT_PLATFORM;
-  const remote = detectRemote(platformOverride);
-
-  if (
-    remote.host === 'none' ||
-    remote.host === 'unknown' ||
-    remote.host === 'azure'
-  ) {
-    return;
-  }
-
-  const creds = resolveGitToken(config, remote);
-  if (!creds) return;
-
-  const apiBase = buildApiBaseUrl(remote, sharedEnv(config).CLANCY_GIT_API_URL);
-  if (!apiBase) return;
+  const handlers = resolvePlatformHandlers(config);
+  if (!handlers) return;
 
   const comment = buildReworkComment(feedback);
 
   // 1. Post rework comment
   try {
-    let posted = false;
-
-    switch (remote.host) {
-      case 'github':
-        posted = await postGitHubPrComment(
-          creds.token,
-          `${remote.owner}/${remote.repo}`,
-          prNumber,
-          comment,
-          apiBase,
-        );
-        break;
-      case 'gitlab':
-        posted = await postMrNote(
-          creds.token,
-          apiBase,
-          remote.projectPath,
-          prNumber,
-          comment,
-        );
-        break;
-      case 'bitbucket':
-        posted = await postCloudPrComment(
-          creds.username!,
-          creds.token,
-          remote.workspace,
-          remote.repoSlug,
-          prNumber,
-          comment,
-        );
-        break;
-      case 'bitbucket-server':
-        posted = await postServerPrComment(
-          creds.token,
-          apiBase,
-          remote.projectKey,
-          remote.repoSlug,
-          prNumber,
-          comment,
-        );
-        break;
-    }
-
+    const posted = await handlers.postComment(prNumber, comment);
     if (posted) {
       console.log(dim('  ✓ Posted rework comment'));
     }
@@ -319,16 +129,10 @@ export async function postReworkActions(
     // Best-effort
   }
 
-  // 2. GitLab: resolve addressed discussion threads
-  if (remote.host === 'gitlab' && discussionIds && discussionIds.length > 0) {
+  // 2. Resolve addressed discussion threads (GitLab — no-op on others)
+  if (discussionIds && discussionIds.length > 0) {
     try {
-      const resolved = await resolveDiscussions(
-        creds.token,
-        apiBase,
-        remote.projectPath,
-        prNumber,
-        discussionIds,
-      );
+      const resolved = await handlers.resolveThreads(prNumber, discussionIds);
       if (resolved > 0) {
         console.log(
           dim(
@@ -341,16 +145,10 @@ export async function postReworkActions(
     }
   }
 
-  // 3. GitHub: re-request review from reviewers who requested changes
-  if (remote.host === 'github' && reviewers && reviewers.length > 0) {
+  // 3. Re-request review from reviewers who requested changes (GitHub — no-op on others)
+  if (reviewers && reviewers.length > 0) {
     try {
-      const ok = await requestGitHubReview(
-        creds.token,
-        `${remote.owner}/${remote.repo}`,
-        prNumber,
-        reviewers,
-        apiBase,
-      );
+      const ok = await handlers.reRequestReview(prNumber, reviewers);
       if (ok) {
         console.log(
           dim(`  ✓ Re-requested review from ${reviewers.join(', ')}`),


### PR DESCRIPTION
## Summary

- **`PlatformReworkHandlers` type** — uniform interface for platform-specific rework operations: `checkReviewState`, `fetchComments`, `postComment`, `resolveThreads`, `reRequestReview`.
- **`resolvePlatformHandlers()` factory** — single switch creates a handler object per platform (github, gitlab, bitbucket, bitbucket-server). Platform-specific no-ops for GitLab-only (resolve threads) and GitHub-only (re-request review) actions.
- **Simplified `rework.ts`** — from 363 to 157 lines. No more dual/triple switch statements. Main functions call `handlers.checkReviewState(branch, since)` instead of switching on `remote.host`.

## Test plan

- [x] All 1288 unit tests pass (`npm test`)
- [x] All 238 integration tests pass (`npm run test:integration`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] DA review — 0 critical, 0 medium

🤖 Generated with [Claude Code](https://claude.com/claude-code)