### PR TITLE
♻️ refactor: remote parsing deduplication (PR 4b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Headers: `✨ Features`, `🐛 Fixes`, `♻️ Refactors`, `✅ Tests`, `📝 Do
 - **Delivery orchestrator simplification** — extracted `readVerificationWarning()`, `buildEpicContext()`, `logOutcome()`, and `progressForOutcome()` helpers. Replaced 6 duplicated `appendProgress` calls in the switch with a single call using `progressForOutcome()`. Applied `computeDeliveryOutcome` to `deliverEpicToBase`. Removed unnecessary `else` in `ensureEpicBranch`. 6 new unit tests.
 - **Board label CRUD consolidation** — shared `modifyLabelList<T>()` (generic read-modify-write with idempotence) and `safeLabel()` (try-catch + warn wrapper) in `src/scripts/board/label-helpers/`. Applied to Jira, Shortcut, Notion, Azure DevOps. Works with both string labels and numeric IDs. 13 new unit tests.
 - **Rework platform handler map** — replaced 3 switch statements in `rework.ts` with `PlatformReworkHandlers` type and `resolvePlatformHandlers()` factory in `rework-handlers.ts`. Single switch creates a handler object; main functions call uniform methods (`checkReviewState`, `fetchComments`, `postComment`, `resolveThreads`, `reRequestReview`). Platform-specific no-ops for GitLab-only and GitHub-only actions.
+- **Remote parsing deduplication** — extracted `buildRemoteInfo()` in `remote.ts` to consolidate the platform-specific path extraction that was duplicated between `parseRemote()` and `overrideRemotePlatform()`. Single switch for all path parsing; `overrideRemotePlatform` reduced to 5 lines.
 
 ---
 

--- a/src/scripts/shared/remote/remote.test.ts
+++ b/src/scripts/shared/remote/remote.test.ts
@@ -277,6 +277,32 @@ describe('remote', () => {
         hostname: 'github.com',
       });
     });
+
+    it('applies bitbucket-server override with scm/ path', () => {
+      execImpl = () => 'https://bb.acme.com/scm/PROJ/repo.git\n';
+
+      const result = detectRemote('bitbucket-server');
+
+      expect(result).toEqual({
+        host: 'bitbucket-server',
+        projectKey: 'PROJ',
+        repoSlug: 'repo',
+        hostname: 'bb.acme.com',
+      });
+    });
+
+    it('applies bitbucket-server override without scm/ prefix', () => {
+      execImpl = () => 'https://bb.acme.com/PROJ/repo.git\n';
+
+      const result = detectRemote('bitbucket-server');
+
+      expect(result).toEqual({
+        host: 'bitbucket-server',
+        projectKey: 'PROJ',
+        repoSlug: 'repo',
+        hostname: 'bb.acme.com',
+      });
+    });
   });
 
   describe('buildApiBaseUrl', () => {

--- a/src/scripts/shared/remote/remote.ts
+++ b/src/scripts/shared/remote/remote.ts
@@ -55,30 +55,34 @@ export function parseRemote(rawUrl: string): RemoteInfo {
   }
 
   const { hostname, path } = extracted;
-
   const platform = detectPlatformFromHostname(hostname);
 
+  return buildRemoteInfo(platform, hostname, path, rawUrl);
+}
+
+/**
+ * Build a RemoteInfo from a known platform, hostname, and path.
+ *
+ * Centralises the platform-specific path extraction that was previously
+ * duplicated in `parseRemote` and `overrideRemotePlatform`.
+ */
+function buildRemoteInfo(
+  platform: string,
+  hostname: string,
+  path: string,
+  rawUrl: string,
+): RemoteInfo {
   switch (platform) {
     case 'github': {
       const parts = path.split('/');
       if (parts.length >= 2) {
-        return {
-          host: 'github',
-          owner: parts[0],
-          repo: parts[1],
-          hostname,
-        };
+        return { host: 'github', owner: parts[0], repo: parts[1], hostname };
       }
       return { host: 'unknown', url: rawUrl };
     }
 
-    case 'gitlab': {
-      return {
-        host: 'gitlab',
-        projectPath: path,
-        hostname,
-      };
-    }
+    case 'gitlab':
+      return { host: 'gitlab', projectPath: path, hostname };
 
     case 'bitbucket': {
       // Bitbucket Server uses /scm/<projectKey>/<repo> format
@@ -98,6 +102,29 @@ export function parseRemote(rawUrl: string): RemoteInfo {
         return {
           host: 'bitbucket',
           workspace: parts[0],
+          repoSlug: parts[1],
+          hostname,
+        };
+      }
+      return { host: 'unknown', url: rawUrl };
+    }
+
+    case 'bitbucket-server': {
+      // Strip leading scm/ prefix used in Bitbucket Server URLs
+      const scmMatch = path.match(/^scm\/([^/]+)\/(.+)$/);
+      if (scmMatch) {
+        return {
+          host: 'bitbucket-server',
+          projectKey: scmMatch[1],
+          repoSlug: scmMatch[2],
+          hostname,
+        };
+      }
+      const parts = path.split('/');
+      if (parts.length >= 2) {
+        return {
+          host: 'bitbucket-server',
+          projectKey: parts[0],
           repoSlug: parts[1],
           hostname,
         };
@@ -174,58 +201,14 @@ export function detectRemote(platformOverride?: string): RemoteInfo {
  */
 function overrideRemotePlatform(rawUrl: string, platform: string): RemoteInfo {
   const extracted = extractHostAndPath(rawUrl);
-
   if (!extracted) return { host: 'unknown', url: rawUrl };
 
-  const { hostname, path } = extracted;
-
-  switch (platform.toLowerCase()) {
-    case 'github': {
-      const parts = path.split('/');
-      if (parts.length >= 2) {
-        return { host: 'github', owner: parts[0], repo: parts[1], hostname };
-      }
-      return { host: 'unknown', url: rawUrl };
-    }
-    case 'gitlab':
-      return { host: 'gitlab', projectPath: path, hostname };
-    case 'bitbucket': {
-      const parts = path.split('/');
-      if (parts.length >= 2) {
-        return {
-          host: 'bitbucket',
-          workspace: parts[0],
-          repoSlug: parts[1],
-          hostname,
-        };
-      }
-      return { host: 'unknown', url: rawUrl };
-    }
-    case 'bitbucket-server': {
-      // Strip leading scm/ prefix used in Bitbucket Server URLs
-      const scmMatch = path.match(/^scm\/([^/]+)\/(.+)$/);
-      if (scmMatch) {
-        return {
-          host: 'bitbucket-server',
-          projectKey: scmMatch[1],
-          repoSlug: scmMatch[2],
-          hostname,
-        };
-      }
-      const parts = path.split('/');
-      if (parts.length >= 2) {
-        return {
-          host: 'bitbucket-server',
-          projectKey: parts[0],
-          repoSlug: parts[1],
-          hostname,
-        };
-      }
-      return { host: 'unknown', url: rawUrl };
-    }
-    default:
-      return { host: 'unknown', url: rawUrl };
-  }
+  return buildRemoteInfo(
+    platform.toLowerCase(),
+    extracted.hostname,
+    extracted.path,
+    rawUrl,
+  );
 }
 
 /**

--- a/src/scripts/shared/remote/remote.ts
+++ b/src/scripts/shared/remote/remote.ts
@@ -67,7 +67,7 @@ export function parseRemote(rawUrl: string): RemoteInfo {
  * duplicated in `parseRemote` and `overrideRemotePlatform`.
  */
 function buildRemoteInfo(
-  platform: string,
+  platform: GitPlatform | string,
   hostname: string,
   path: string,
   rawUrl: string,
@@ -85,16 +85,9 @@ function buildRemoteInfo(
       return { host: 'gitlab', projectPath: path, hostname };
 
     case 'bitbucket': {
-      // Bitbucket Server uses /scm/<projectKey>/<repo> format
-      const scmMatch = path.match(/^scm\/([^/]+)\/(.+)$/);
-      if (scmMatch) {
-        return {
-          host: 'bitbucket-server',
-          projectKey: scmMatch[1],
-          repoSlug: scmMatch[2],
-          hostname,
-        };
-      }
+      // Bitbucket Server uses /scm/<projectKey>/<repo> format — detect and redirect
+      const serverInfo = parseBitbucketServerPath(path, hostname);
+      if (serverInfo) return serverInfo;
 
       // Bitbucket Cloud: <workspace>/<repo>
       const parts = path.split('/');
@@ -110,16 +103,10 @@ function buildRemoteInfo(
     }
 
     case 'bitbucket-server': {
-      // Strip leading scm/ prefix used in Bitbucket Server URLs
-      const scmMatch = path.match(/^scm\/([^/]+)\/(.+)$/);
-      if (scmMatch) {
-        return {
-          host: 'bitbucket-server',
-          projectKey: scmMatch[1],
-          repoSlug: scmMatch[2],
-          hostname,
-        };
-      }
+      const serverInfo = parseBitbucketServerPath(path, hostname);
+      if (serverInfo) return serverInfo;
+
+      // Plain <projectKey>/<repo> without scm/ prefix
       const parts = path.split('/');
       if (parts.length >= 2) {
         return {
@@ -135,9 +122,25 @@ function buildRemoteInfo(
     case 'azure':
       return { host: 'azure', url: rawUrl };
 
+    case 'unknown':
     default:
       return { host: 'unknown', url: rawUrl };
   }
+}
+
+/** Parse Bitbucket Server /scm/<projectKey>/<repo> path format. */
+function parseBitbucketServerPath(
+  path: string,
+  hostname: string,
+): RemoteInfo | undefined {
+  const scmMatch = path.match(/^scm\/([^/]+)\/(.+)$/);
+  if (!scmMatch) return undefined;
+  return {
+    host: 'bitbucket-server',
+    projectKey: scmMatch[1],
+    repoSlug: scmMatch[2],
+    hostname,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- **`buildRemoteInfo()` helper** — consolidates the platform-specific path extraction (GitHub owner/repo, GitLab projectPath, Bitbucket workspace/repoSlug, Bitbucket Server projectKey/scm prefix) that was duplicated between `parseRemote()` and `overrideRemotePlatform()`.
- **`overrideRemotePlatform` simplified** — from 47 lines with its own switch to 5 lines delegating to `buildRemoteInfo()`.
- Single switch for all path parsing. No new files — pure deduplication within `remote.ts`.

## Test plan

- [x] All 1299 unit tests pass (`npm test`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] All 39 existing remote parsing tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)