### PR TITLE
📦 chore: ESLint complexity enforcement — ratchet strategy (PR 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Headers: `✨ Features`, `🐛 Fixes`, `♻️ Refactors`, `✅ Tests`, `📝 Do
 - **Rework platform handler map** — replaced 3 switch statements in `rework.ts` with `PlatformReworkHandlers` type and `resolvePlatformHandlers()` factory in `rework-handlers.ts`. Single switch creates a handler object; main functions call uniform methods (`checkReviewState`, `fetchComments`, `postComment`, `resolveThreads`, `reRequestReview`). Platform-specific no-ops for GitLab-only and GitHub-only actions.
 - **Remote parsing deduplication** — extracted `buildRemoteInfo()` in `remote.ts` to consolidate the platform-specific path extraction that was duplicated between `parseRemote()` and `overrideRemotePlatform()`. Single switch for all path parsing; `overrideRemotePlatform` reduced to 5 lines.
 - **Housekeeping** — renamed `retry.ts` → `retry-fetch.ts` (matches primary export `retryFetch`). Added 5 co-located unit tests for `copyRoleFiles`. Extended `docs/CONVENTIONS.md` with error handling, import style, and v0.8.24 patterns sections.
+- **ESLint complexity enforcement** — added 8 rules: `max-lines-per-function` (60), `max-depth` (3), `complexity` (10), `max-lines` (300), `prefer-const`, `no-floating-promises`, `switch-exhaustiveness-check`. Fixed 6 errors (2 floating promises, 4 non-exhaustive switches). Ratchet strategy: `--max-warnings 234` enforced in lint script — any new code must not increase the warning count.
 
 ---
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -18,6 +18,32 @@ export default tseslint.config(
         'error',
         { argsIgnorePattern: '^_' },
       ],
+
+      // ── Complexity rules (v0.8.24) ──────────────────────────────────────
+      'max-lines-per-function': [
+        'warn',
+        { max: 60, skipComments: true, skipBlankLines: true },
+      ],
+      'max-depth': ['warn', 3],
+      complexity: ['warn', 10],
+      'max-lines': [
+        'warn',
+        { max: 300, skipComments: true, skipBlankLines: true },
+      ],
+      'prefer-const': 'error',
+    },
+  },
+  // Typed rules require parserOptions.project
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.json',
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:fixtures:validate": "npx tsx test/integration/validate-fixtures.ts",
     "test:fixtures:live": "npx tsx test/e2e/validate-live-schemas.ts",
     "test:coverage": "vitest run --coverage",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 234",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/src/scripts/afk/afk.ts
+++ b/src/scripts/afk/afk.ts
@@ -304,5 +304,5 @@ if (
 ) {
   const scriptDir = dirname(fileURLToPath(import.meta.url));
   const maxIterations = parseInt(process.env.MAX_ITERATIONS ?? '5', 10) || 5;
-  runAfkLoop(scriptDir, maxIterations);
+  void runAfkLoop(scriptDir, maxIterations);
 }

--- a/src/scripts/once/git-token/git-token.ts
+++ b/src/scripts/once/git-token/git-token.ts
@@ -28,6 +28,10 @@ export function resolveGitToken(
     case 'bitbucket-server':
       if (env.BITBUCKET_TOKEN) return { token: env.BITBUCKET_TOKEN };
       break;
+    case 'none':
+    case 'unknown':
+    case 'azure':
+      break;
   }
   return undefined;
 }

--- a/src/scripts/once/once.ts
+++ b/src/scripts/once/once.ts
@@ -109,5 +109,5 @@ if (
   process.argv[1] &&
   fileURLToPath(import.meta.url) === resolve(process.argv[1])
 ) {
-  run(process.argv);
+  void run(process.argv);
 }

--- a/src/scripts/once/pr-creation/pr-creation.ts
+++ b/src/scripts/once/pr-creation/pr-creation.ts
@@ -75,7 +75,9 @@ export async function attemptPrCreation(
         body,
       );
 
-    default:
+    case 'none':
+    case 'unknown':
+    case 'azure':
       return undefined;
   }
 }

--- a/src/scripts/shared/pull-request/pr-body/pr-body.ts
+++ b/src/scripts/shared/pull-request/pr-body/pr-body.ts
@@ -87,6 +87,11 @@ export function buildPrBody(
     case 'linear':
       lines.push(`**Linear:** ${ticket.key}`);
       break;
+    case 'shortcut':
+    case 'notion':
+    case 'azdo':
+      lines.push(`**Ticket:** ${ticket.key}`);
+      break;
   }
 
   lines.push('');

--- a/src/scripts/shared/remote/remote.ts
+++ b/src/scripts/shared/remote/remote.ts
@@ -238,7 +238,9 @@ export function buildApiBaseUrl(
       return 'https://api.bitbucket.org/2.0';
     case 'bitbucket-server':
       return `https://${remote.hostname}/rest/api/1.0`;
-    default:
+    case 'none':
+    case 'unknown':
+    case 'azure':
       return undefined;
   }
 }


### PR DESCRIPTION
## Summary

**8 new ESLint rules** for code quality enforcement:

| Rule | Level | Threshold |
|---|---|---|
| `max-lines-per-function` | warn | 60 lines |
| `max-depth` | warn | 3 |
| `complexity` | warn | 10 |
| `max-lines` | warn | 300 lines |
| `prefer-const` | error | — |
| `no-floating-promises` | error | — |
| `switch-exhaustiveness-check` | error | — |
| `consistent-type-imports` | error | (already existed) |

**6 errors fixed:**
- 2 floating promises (`afk.ts`, `once.ts` entry points → `void`)
- 4 non-exhaustive switches (`git-token`, `pr-creation`, `pr-body`, `remote`)

**Ratchet strategy:** `--max-warnings 234` in the lint script. Any new code that adds warnings will fail the lint check. Target: reduce to 0 in post-epic work.

**Warning breakdown:** 140 function length + 35 complexity + 30 nesting depth + 27 file length = 232 (+ 2 misc) = 234 total.

## Test plan

- [x] All 1306 unit tests pass (`npm test`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` passes with `--max-warnings 234`
- [x] 0 errors, 234 warnings (ratchet baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)